### PR TITLE
Add dynamic grammar parser and static lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,36 @@ programming language
 - add static storage
 - add multithread support (maybe)
 
-## Dynamic tokenizer
+## Dynamic parser and static tokenizer
 
-The lexer loads token rules from a text file. Each non-empty line describes a
-token as `<NAME> <literal>`, for example:
+The lexer now uses static rules (identifiers, numbers, punctuation) while the
+parser consumes a grammar loaded from a text file. Grammar files support
+`:=` (define) and `+=` (append) operators, rule references with `$name`, and
+token-kind matches with `%KIND`.
+
+Example grammar excerpt:
 
 ```
-LBRACE {
-RBRACE }
-ARROW "->"
-PLUS +
+start := $function
+function := %IDENT "(" $params ")" "->" $expr ";"
+params := %IDENT $params_tail
+params +=
+params_tail := "," %IDENT $params_tail
+params_tail +=
+expr := $term $expr_tail
+expr_tail := "+" $term $expr_tail
+expr_tail +=
+term := $factor $term_tail
+term_tail := "*" $factor $term_tail
+term_tail +=
+factor := "(" $expr ")"
+factor += %IDENT
+factor += %NUMBER
 ```
 
-Quoted literals support the escapes `\n`, `\t`, `\\`, and `\"`. After loading
-the syntax file, the compiler tokenizes a source file that you provide on the
-command line:
+Build and run using a grammar file and source program:
 
 ```
 cmake -S . -B build && cmake --build build
-./build/src/morphlc examples/syntax.txt examples/program.src
+./build/src/morphlc examples/grammar.txt examples/program.src
 ```
-
-Identifiers and numbers are recognized automatically, and an EOF token is
-appended to every token stream.

--- a/examples/grammar.txt
+++ b/examples/grammar.txt
@@ -1,0 +1,22 @@
+start := $function
+
+function := %IDENT "(" $params ")" "->" $expr ";"
+
+params := %IDENT $params_tail
+params +=
+params_tail := "," %IDENT $params_tail
+params_tail +=
+
+expr := $term $expr_tail
+expr_tail := "+" $term $expr_tail
+expr_tail += "-" $term $expr_tail
+expr_tail +=
+
+term := $factor $term_tail
+term_tail := "*" $factor $term_tail
+term_tail += "/" $factor $term_tail
+term_tail +=
+
+factor := "(" $expr ")"
+factor += %IDENT
+factor += %NUMBER

--- a/include/lexer/lexer.h
+++ b/include/lexer/lexer.h
@@ -5,42 +5,36 @@
 #include <stdbool.h>
 #include "tokens/tokens.h"
 
-typedef struct SyntaxRule {
-  TokenKind kind;
-  Str literal;
-} SyntaxRule;
-
-typedef struct Syntax {
-  SyntaxRule* rules;
-  size_t rule_count;
-  size_t rule_capacity;
-  InternTable* kinds;
-} Syntax;
-
-// Load syntax rules from a file. Each non-empty, non-comment line should be in
-// the form:
-//   TOKEN_NAME literal
-// The literal may be unquoted (single word) or wrapped in double quotes when it
-// contains whitespace. Backslash escapes (\n, \t, \\ and \") are honored in
-// quoted literals. TOKEN_NAME is interned and used as the token kind.
-bool syntax_load_file(Syntax* syntax, const char* path, InternTable* interns, Arena* arena);
-void syntax_free(Syntax* syntax);
-
-// Tokenize a source string using the supplied syntax. Identifiers (/[A-Za-z_][A-Za-z0-9_]*/) are
-// emitted as the IDENT kind, numbers (/[0-9]+/) as NUMBER, and any unknown
-// character as UNKNOWN. An EOF token is appended to the end of the stream.
-bool lexer_tokenize(const Syntax* syntax,
-                    const char* filename,
+/**
+ * @brief Tokenize a source buffer using a static rule set.
+ *
+ * The lexer recognizes identifiers (`[A-Za-z_][A-Za-z0-9_]*`), decimal
+ * numbers (`[0-9]+`), and punctuation sequences (any run of non-whitespace
+ * characters that are not alphanumeric or an underscore). Whitespace is
+ * ignored while tracking row/column positions. An explicit EOF token is
+ * appended to every stream. All token kinds are interned using the provided
+ * table, allowing the parser to reference kinds symbolically.
+ *
+ * @param filename The name of the file being tokenized (used for diagnostics).
+ * @param source   The source buffer to scan.
+ * @param interns  The intern table used to store token kind strings.
+ * @param out_tokens Pointer that receives a heap-allocated array of tokens.
+ * @param out_count  Pointer that receives the number of tokens produced.
+ * @return true on success, false on allocation or interning failure.
+ */
+bool lexer_tokenize(const char* filename,
                     Str source,
                     InternTable* interns,
                     struct token** out_tokens,
                     size_t* out_count);
 
-// Common token kind strings that are always interned by the lexer.
-extern const char* const LEXER_KIND_IDENT;
-extern const char* const LEXER_KIND_NUMBER;
-extern const char* const LEXER_KIND_UNKNOWN;
-extern const char* const LEXER_KIND_EOF;
+/** @name Built-in token kinds */
+///@{
+extern const char* const LEXER_KIND_IDENT;   /**< Identifier token kind name. */
+extern const char* const LEXER_KIND_NUMBER;  /**< Number token kind name. */
+extern const char* const LEXER_KIND_SYMBOL;  /**< Punctuation token kind name. */
+extern const char* const LEXER_KIND_EOF;     /**< End-of-file token kind name. */
+///@}
 
 
 #endif // MORPHL_LEXER_LEXER_H_

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -1,0 +1,109 @@
+#ifndef MORPHL_PARSER_PARSER_H_
+#define MORPHL_PARSER_PARSER_H_
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "tokens/tokens.h"
+
+/**
+ * @brief Specifies the kind of atom a grammar production can contain.
+ */
+typedef enum GrammarAtomKind {
+  GRAMMAR_ATOM_LITERAL,   /**< A literal token lexeme to match. */
+  GRAMMAR_ATOM_RULE,      /**< A reference to another grammar rule (e.g. `$name`). */
+  GRAMMAR_ATOM_TOKEN_KIND /**< A token-kind match (e.g. `%IDENT`). */
+} GrammarAtomKind;
+
+/**
+ * @brief A single production atom, either a literal token, a rule reference, or
+ * a token-kind match.
+ */
+typedef struct GrammarAtom {
+  GrammarAtomKind kind; /**< The atom type. */
+  Sym symbol;           /**< Rule name or token kind, depending on @ref kind. */
+  Str literal;          /**< Literal token text for GRAMMAR_ATOM_LITERAL. */
+} GrammarAtom;
+
+/**
+ * @brief A production rule represented as a sequence of atoms.
+ */
+typedef struct Production {
+  GrammarAtom* atoms;      /**< Ordered atoms in this production. */
+  size_t atom_count;       /**< Number of atoms. */
+  size_t atom_capacity;    /**< Allocated atom slots. */
+} Production;
+
+/**
+ * @brief A named grammar rule with one or more productions.
+ */
+typedef struct GrammarRule {
+  Sym name;                /**< Interned rule name. */
+  Production* productions; /**< Production list. */
+  size_t production_count; /**< Number of productions. */
+  size_t production_cap;   /**< Allocated production slots. */
+} GrammarRule;
+
+/**
+ * @brief Dynamic grammar loaded from a text description.
+ *
+ * Grammar files support the following syntax:
+ * - `name := ...` declares a rule and replaces any previous productions.
+ * - `name += ...` appends an additional production to an existing rule.
+ * - `$other` inserts a reference to another rule named `other`.
+ * - `%KIND` matches a token kind by name (for example `%IDENT`).
+ * - Bare words or quoted strings match literal token lexemes.
+ * - Empty productions are allowed by omitting atoms after the operator.
+ */
+typedef struct Grammar {
+  GrammarRule* rules;      /**< Rule list. */
+  size_t rule_count;       /**< Number of rules. */
+  size_t rule_cap;         /**< Allocated rule slots. */
+  Sym start_rule;          /**< Start symbol (first rule seen). */
+  InternTable* names;      /**< Intern table for rule/kind names. */
+} Grammar;
+
+/**
+ * @brief Load a grammar from a text file.
+ *
+ * @param grammar Destination grammar structure to populate.
+ * @param path    Path to the grammar description file.
+ * @param interns Intern table used to intern rule names and token kinds.
+ * @param arena   Arena used to store literal strings for the lifetime of the grammar.
+ * @return true on success, false on parse or allocation failure.
+ */
+bool grammar_load_file(Grammar* grammar,
+                       const char* path,
+                       InternTable* interns,
+                       Arena* arena);
+
+/**
+ * @brief Release grammar allocations.
+ *
+ * Literal strings are owned by the provided arena; only dynamic arrays are
+ * freed here.
+ */
+void grammar_free(Grammar* grammar);
+
+/**
+ * @brief Parse a token stream according to the supplied grammar.
+ *
+ * This routine performs a depth-first search over productions, consuming tokens
+ * when atoms match. For literal atoms the token lexeme must match exactly;
+ * token-kind atoms match by kind symbol; rule atoms recursively invoke the
+ * referenced rule. The parse succeeds only when the start rule consumes all
+ * tokens supplied.
+ *
+ * @param grammar     Grammar to use.
+ * @param start_rule  Optional start symbol; when zero the grammar's first rule
+ *                    is used.
+ * @param tokens      Token stream to parse.
+ * @param token_count Number of tokens in the stream.
+ * @return true when the entire token sequence is accepted.
+ */
+bool grammar_parse(const Grammar* grammar,
+                   Sym start_rule,
+                   const struct token* tokens,
+                   size_t token_count);
+
+#endif // MORPHL_PARSER_PARSER_H_

--- a/include/tokens/tokens.h
+++ b/include/tokens/tokens.h
@@ -6,16 +6,18 @@
 #include <stdbool.h>
 #include "util/util.h"
 
-// A token kind is identified by an interned symbol, allowing the lexer to
-// accept syntax rules that are loaded at runtime.
+/** A token kind is identified by an interned symbol. */
 typedef Sym TokenKind;
 
+/**
+ * @brief Represents a lexical token with source location metadata.
+ */
 struct token {
-  TokenKind kind;
-  Str lexeme;
-  const char* filename;
-  size_t row;
-  size_t col;
+  TokenKind kind;      /**< Interned token kind. */
+  Str lexeme;          /**< Token text. */
+  const char* filename;/**< Originating filename. */
+  size_t row;          /**< 1-based line number. */
+  size_t col;          /**< 1-based column number. */
 };
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(morphlc PUBLIC
 
 add_subdirectory(util)
 add_subdirectory(lexer)
+add_subdirectory(parser)
 
 
 

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -9,151 +9,8 @@
 
 const char* const LEXER_KIND_IDENT = "IDENT";
 const char* const LEXER_KIND_NUMBER = "NUMBER";
-const char* const LEXER_KIND_UNKNOWN = "UNKNOWN";
+const char* const LEXER_KIND_SYMBOL = "SYMBOL";
 const char* const LEXER_KIND_EOF = "EOF";
-
-static bool push_rule(Syntax* syntax, SyntaxRule rule) {
-  if (syntax->rule_count == syntax->rule_capacity) {
-    size_t new_cap = syntax->rule_capacity ? syntax->rule_capacity * 2 : 8;
-    SyntaxRule* resized = realloc(syntax->rules, new_cap * sizeof(SyntaxRule));
-    if (!resized) return false;
-    syntax->rules = resized;
-    syntax->rule_capacity = new_cap;
-  }
-  syntax->rules[syntax->rule_count++] = rule;
-  return true;
-}
-
-static void trim_whitespace(const char** line, size_t* len) {
-  while (*len > 0 && isspace((unsigned char)(*line)[0])) {
-    (*line)++; (*len)--;
-  }
-  while (*len > 0 && isspace((unsigned char)(*line)[*len - 1])) {
-    (*len)--;
-  }
-}
-
-static bool parse_literal(const char** cursor, size_t* remaining, Str* out, bool* allocated) {
-  const char* start = *cursor;
-  size_t len = 0;
-  if (*remaining == 0) return false;
-  if (allocated) *allocated = false;
-  if (**cursor == '"') {
-    (*cursor)++; (*remaining)--;
-    char* buf = malloc(*remaining + 1);
-    if (!buf) return false;
-    size_t out_len = 0;
-    bool closed = false;
-    while (*remaining > 0) {
-      char c = **cursor;
-      (*cursor)++; (*remaining)--;
-      if (c == '"') { closed = true; break; }
-      if (c == '\\' && *remaining > 0) {
-        char esc = **cursor; (*cursor)++; (*remaining)--;
-        switch (esc) {
-          case 'n': c = '\n'; break;
-          case 't': c = '\t'; break;
-          case '\\': c = '\\'; break;
-          case '"': c = '"'; break;
-          default: c = esc; break;
-        }
-      }
-      buf[out_len++] = c;
-    }
-    if (!closed) { free(buf); return false; }
-    buf[out_len] = '\0';
-    *out = str_from(buf, out_len);
-    if (allocated) *allocated = true;
-    return true;
-  }
-  while (len < *remaining && !isspace((unsigned char)start[len])) {
-    len++;
-  }
-  if (len == 0) return false;
-  *out = str_from(start, len);
-  *cursor += len;
-  *remaining -= len;
-  return true;
-}
-
-static bool parse_rule_line(const char* line, size_t len, InternTable* interns, Arena* arena, SyntaxRule* out_rule) {
-  trim_whitespace(&line, &len);
-  if (len == 0 || line[0] == '#') return false;
-
-  // Parse token name
-  size_t name_len = 0;
-  while (name_len < len && !isspace((unsigned char)line[name_len])) {
-    name_len++;
-  }
-  if (name_len == 0) return false;
-  Str name = str_from(line, name_len);
-  line += name_len;
-  len -= name_len;
-  trim_whitespace(&line, &len);
-  Str literal;
-  bool literal_allocated = false;
-  if (!parse_literal(&line, &len, &literal, &literal_allocated)) return false;
-
-  // Copy literal into arena to keep lifetime alongside syntax
-  const char* literal_buf = literal.ptr;
-  char* stored = arena_push(arena, literal.ptr, literal.len + 1);
-  if (!stored) return false;
-  stored[literal.len] = '\0';
-  literal = str_from(stored, literal.len);
-  if (literal_allocated) {
-    free((void*)literal_buf);
-  }
-
-  TokenKind kind = interns_intern(interns, name);
-  if (!kind) return false;
-  *out_rule = (SyntaxRule){ .kind = kind, .literal = literal };
-  return true;
-}
-
-bool syntax_load_file(Syntax* syntax, const char* path, InternTable* interns, Arena* arena) {
-  if (!syntax || !interns || !arena) return false;
-  memset(syntax, 0, sizeof(*syntax));
-  syntax->kinds = interns;
-
-  char* contents = NULL;
-  size_t len = 0;
-  if (!file_read_all(path, &contents, &len)) {
-    return false;
-  }
-
-  const char* cursor = contents;
-  while (len > 0) {
-    const char* line = cursor;
-    size_t line_len = 0;
-    while (line_len < len && cursor[line_len] != '\n') {
-      line_len++;
-    }
-    cursor += line_len + (line_len < len);
-    len -= line_len + (line_len < len);
-
-    SyntaxRule rule;
-    if (parse_rule_line(line, line_len, interns, arena, &rule)) {
-      if (!push_rule(syntax, rule)) { free(contents); return false; }
-    }
-  }
-
-  free(contents);
-  return true;
-}
-
-void syntax_free(Syntax* syntax) {
-  if (!syntax) return;
-  free(syntax->rules);
-  syntax->rules = NULL;
-  syntax->rule_count = 0;
-  syntax->rule_capacity = 0;
-  syntax->kinds = NULL;
-}
-
-static bool match_rule(const SyntaxRule* rule, Str remaining) {
-  return remaining.len >= rule->literal.len &&
-         memcmp(remaining.ptr, rule->literal.ptr, rule->literal.len) == 0;
-}
 
 static bool ensure_token_capacity(struct token** tokens, size_t* cap, size_t needed) {
   if (*cap >= needed) return true;
@@ -166,22 +23,32 @@ static bool ensure_token_capacity(struct token** tokens, size_t* cap, size_t nee
   return true;
 }
 
-bool lexer_tokenize(const Syntax* syntax,
-                    const char* filename,
+static bool intern_kinds(InternTable* interns,
+                         TokenKind* ident,
+                         TokenKind* number,
+                         TokenKind* symbol,
+                         TokenKind* eof) {
+  *ident = interns_intern(interns, str_from(LEXER_KIND_IDENT, strlen(LEXER_KIND_IDENT)));
+  *number = interns_intern(interns, str_from(LEXER_KIND_NUMBER, strlen(LEXER_KIND_NUMBER)));
+  *symbol = interns_intern(interns, str_from(LEXER_KIND_SYMBOL, strlen(LEXER_KIND_SYMBOL)));
+  *eof = interns_intern(interns, str_from(LEXER_KIND_EOF, strlen(LEXER_KIND_EOF)));
+  return *ident && *number && *symbol && *eof;
+}
+
+bool lexer_tokenize(const char* filename,
                     Str source,
                     InternTable* interns,
                     struct token** out_tokens,
                     size_t* out_count) {
-  if (!syntax || !interns || !out_tokens || !out_count) return false;
+  if (!interns || !out_tokens || !out_count) return false;
   *out_tokens = NULL;
   *out_count = 0;
   size_t cap = 0;
 
-  TokenKind ident_kind = interns_intern(interns, str_from(LEXER_KIND_IDENT, strlen(LEXER_KIND_IDENT)));
-  TokenKind number_kind = interns_intern(interns, str_from(LEXER_KIND_NUMBER, strlen(LEXER_KIND_NUMBER)));
-  TokenKind unknown_kind = interns_intern(interns, str_from(LEXER_KIND_UNKNOWN, strlen(LEXER_KIND_UNKNOWN)));
-  TokenKind eof_kind = interns_intern(interns, str_from(LEXER_KIND_EOF, strlen(LEXER_KIND_EOF)));
-  if (!ident_kind || !number_kind || !unknown_kind || !eof_kind) return false;
+  TokenKind ident_kind, number_kind, symbol_kind, eof_kind;
+  if (!intern_kinds(interns, &ident_kind, &number_kind, &symbol_kind, &eof_kind)) {
+    return false;
+  }
 
   size_t offset = 0;
   size_t row = 1, col = 1;
@@ -189,31 +56,6 @@ bool lexer_tokenize(const Syntax* syntax,
     char c = source.ptr[offset];
     if (c == '\n') { row++; col = 1; offset++; continue; }
     if (c == ' ' || c == '\t' || c == '\r') { col++; offset++; continue; }
-
-    SyntaxRule const* match = NULL;
-    size_t match_len = 0;
-    for (size_t i = 0; i < syntax->rule_count; ++i) {
-      const SyntaxRule* rule = &syntax->rules[i];
-      if (match_rule(rule, str_from(source.ptr + offset, source.len - offset)) &&
-          rule->literal.len > match_len) {
-        match = rule;
-        match_len = rule->literal.len;
-      }
-    }
-
-    if (match) {
-      if (!ensure_token_capacity(out_tokens, &cap, *out_count + 1)) return false;
-      (*out_tokens)[(*out_count)++] = (struct token){
-        .kind = match->kind,
-        .lexeme = str_from(source.ptr + offset, match_len),
-        .filename = filename,
-        .row = row,
-        .col = col,
-      };
-      offset += match_len;
-      col += match_len;
-      continue;
-    }
 
     if (isalpha((unsigned char)c) || c == '_') {
       size_t start = offset;
@@ -251,16 +93,27 @@ bool lexer_tokenize(const Syntax* syntax,
       continue;
     }
 
-    // Unknown character
+    size_t start = offset;
+    while (offset < source.len) {
+      char cc = source.ptr[offset];
+      if (isalnum((unsigned char)cc) || cc == '_' || isspace((unsigned char)cc)) break;
+      offset++; col++;
+    }
+    size_t len = offset - start;
+    if (len == 0) {
+      // Should not happen, but avoid infinite loop.
+      offset++; col++;
+      continue;
+    }
+
     if (!ensure_token_capacity(out_tokens, &cap, *out_count + 1)) return false;
     (*out_tokens)[(*out_count)++] = (struct token){
-      .kind = unknown_kind,
-      .lexeme = str_from(source.ptr + offset, 1),
+      .kind = symbol_kind,
+      .lexeme = str_from(source.ptr + start, len),
       .filename = filename,
       .row = row,
-      .col = col,
+      .col = col - len,
     };
-    offset++; col++;
   }
 
   if (!ensure_token_capacity(out_tokens, &cap, *out_count + 1)) return false;

--- a/src/main.c
+++ b/src/main.c
@@ -2,16 +2,17 @@
 #include <stdlib.h>
 
 #include "lexer/lexer.h"
+#include "parser/parser.h"
 #include "util/file.h"
 #include "util/util.h"
 
 int main(int argc, char** argv) {
   if (argc < 3) {
-    fprintf(stderr, "usage: %s <syntax-file> <source-file>\n", argv[0]);
+    fprintf(stderr, "usage: %s <grammar-file> <source-file>\n", argv[0]);
     return 1;
   }
 
-  const char* syntax_path = argv[1];
+  const char* grammar_path = argv[1];
   const char* source_path = argv[2];
 
   InternTable* interns = interns_new();
@@ -23,9 +24,9 @@ int main(int argc, char** argv) {
   Arena arena;
   arena_init(&arena, 4096);
 
-  Syntax syntax;
-  if (!syntax_load_file(&syntax, syntax_path, interns, &arena)) {
-    fprintf(stderr, "failed to load syntax from %s\n", syntax_path);
+  Grammar grammar;
+  if (!grammar_load_file(&grammar, grammar_path, interns, &arena)) {
+    fprintf(stderr, "failed to load grammar from %s\n", grammar_path);
     arena_free(&arena);
     interns_free(interns);
     return 1;
@@ -35,7 +36,7 @@ int main(int argc, char** argv) {
   size_t source_len = 0;
   if (!file_read_all(source_path, &source_buffer, &source_len)) {
     fprintf(stderr, "failed to read source from %s\n", source_path);
-    syntax_free(&syntax);
+    grammar_free(&grammar);
     arena_free(&arena);
     interns_free(interns);
     return 1;
@@ -43,28 +44,21 @@ int main(int argc, char** argv) {
 
   struct token* tokens = NULL;
   size_t token_count = 0;
-  if (!lexer_tokenize(&syntax, source_path, str_from(source_buffer, source_len), interns, &tokens, &token_count)) {
+  if (!lexer_tokenize(source_path, str_from(source_buffer, source_len), interns, &tokens, &token_count)) {
     fprintf(stderr, "tokenization failed\n");
     free(source_buffer);
-    syntax_free(&syntax);
+    grammar_free(&grammar);
     arena_free(&arena);
     interns_free(interns);
     return 1;
   }
 
-  for (size_t i = 0; i < token_count; ++i) {
-    Str kind = interns_lookup(interns, tokens[i].kind);
-    printf("%s (%zu:%zu): %.*s\n",
-           kind.ptr ? kind.ptr : "<invalid>",
-           tokens[i].row,
-           tokens[i].col,
-           (int)tokens[i].lexeme.len,
-           tokens[i].lexeme.ptr ? tokens[i].lexeme.ptr : "");
-  }
+  bool accepted = grammar_parse(&grammar, 0, tokens, token_count);
+  printf("parse %s\n", accepted ? "succeeded" : "failed");
 
   free(tokens);
   free(source_buffer);
-  syntax_free(&syntax);
+  grammar_free(&grammar);
   arena_free(&arena);
   interns_free(interns);
   return 0;

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(morphl_parser
+  parser.c
+)
+
+target_link_libraries(morphl_parser PUBLIC morphl_util)
+target_link_libraries(morphlc PRIVATE morphl_parser)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,0 +1,356 @@
+#include "parser/parser.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lexer/lexer.h"
+#include "util/file.h"
+
+#define PARSER_MAX_DEPTH 128
+
+static bool ensure_rule_capacity(Grammar* grammar) {
+  if (grammar->rule_count < grammar->rule_cap) return true;
+  size_t new_cap = grammar->rule_cap ? grammar->rule_cap * 2 : 8;
+  GrammarRule* resized = realloc(grammar->rules, new_cap * sizeof(GrammarRule));
+  if (!resized) return false;
+  grammar->rules = resized;
+  grammar->rule_cap = new_cap;
+  return true;
+}
+
+static bool ensure_production_capacity(GrammarRule* rule) {
+  if (rule->production_count < rule->production_cap) return true;
+  size_t new_cap = rule->production_cap ? rule->production_cap * 2 : 4;
+  Production* resized = realloc(rule->productions, new_cap * sizeof(Production));
+  if (!resized) return false;
+  rule->productions = resized;
+  rule->production_cap = new_cap;
+  return true;
+}
+
+static bool ensure_atom_capacity(Production* prod) {
+  if (prod->atom_count < prod->atom_capacity) return true;
+  size_t new_cap = prod->atom_capacity ? prod->atom_capacity * 2 : 4;
+  GrammarAtom* resized = realloc(prod->atoms, new_cap * sizeof(GrammarAtom));
+  if (!resized) return false;
+  prod->atoms = resized;
+  prod->atom_capacity = new_cap;
+  return true;
+}
+
+static void reset_rule(GrammarRule* rule) {
+  for (size_t i = 0; i < rule->production_count; ++i) {
+    free(rule->productions[i].atoms);
+  }
+  free(rule->productions);
+  memset(rule, 0, sizeof(*rule));
+}
+
+static void trim_whitespace(const char** line, size_t* len) {
+  while (*len > 0 && isspace((unsigned char)(*line)[0])) {
+    (*line)++; (*len)--;
+  }
+  while (*len > 0 && isspace((unsigned char)(*line)[*len - 1])) {
+    (*len)--;
+  }
+}
+
+static bool parse_literal(const char** cursor, size_t* remaining, Str* out, bool* allocated) {
+  const char* start = *cursor;
+  size_t len = 0;
+  if (*remaining == 0) return false;
+  if (allocated) *allocated = false;
+  if (**cursor == '"') {
+    (*cursor)++; (*remaining)--;
+    char* buf = malloc(*remaining + 1);
+    if (!buf) return false;
+    size_t out_len = 0;
+    bool closed = false;
+    while (*remaining > 0) {
+      char c = **cursor;
+      (*cursor)++; (*remaining)--;
+      if (c == '"') { closed = true; break; }
+      if (c == '\\' && *remaining > 0) {
+        char esc = **cursor; (*cursor)++; (*remaining)--;
+        switch (esc) {
+          case 'n': c = '\n'; break;
+          case 't': c = '\t'; break;
+          case '\\': c = '\\'; break;
+          case '"': c = '"'; break;
+          default: c = esc; break;
+        }
+      }
+      buf[out_len++] = c;
+    }
+    if (!closed) { free(buf); return false; }
+    buf[out_len] = '\0';
+    *out = str_from(buf, out_len);
+    if (allocated) *allocated = true;
+    return true;
+  }
+  while (len < *remaining && !isspace((unsigned char)start[len])) {
+    len++;
+  }
+  if (len == 0) return false;
+  *out = str_from(start, len);
+  *cursor += len;
+  *remaining -= len;
+  return true;
+}
+
+static GrammarRule* find_or_add_rule(Grammar* grammar, Sym name) {
+  for (size_t i = 0; i < grammar->rule_count; ++i) {
+    if (grammar->rules[i].name == name) {
+      return &grammar->rules[i];
+    }
+  }
+  if (!ensure_rule_capacity(grammar)) return NULL;
+  GrammarRule* slot = &grammar->rules[grammar->rule_count++];
+  memset(slot, 0, sizeof(*slot));
+  slot->name = name;
+  if (grammar->start_rule == 0) {
+    grammar->start_rule = name;
+  }
+  return slot;
+}
+
+static bool parse_atom(const char** line,
+                       size_t* len,
+                       InternTable* interns,
+                       Arena* arena,
+                       GrammarAtom* out_atom) {
+  trim_whitespace(line, len);
+  if (*len == 0) return false;
+  bool literal_allocated = false;
+  Str raw;
+  if (!parse_literal(line, len, &raw, &literal_allocated)) return false;
+  GrammarAtom atom = {0};
+  if (raw.len > 0 && raw.ptr[0] == '$') {
+    Str name = str_from(raw.ptr + 1, raw.len - 1);
+    atom.kind = GRAMMAR_ATOM_RULE;
+    atom.symbol = interns_intern(interns, name);
+    if (literal_allocated) free((void*)raw.ptr);
+    if (!atom.symbol) return false;
+  } else if (raw.len > 0 && raw.ptr[0] == '%') {
+    Str kind = str_from(raw.ptr + 1, raw.len - 1);
+    atom.kind = GRAMMAR_ATOM_TOKEN_KIND;
+    atom.symbol = interns_intern(interns, kind);
+    if (literal_allocated) free((void*)raw.ptr);
+    if (!atom.symbol) return false;
+  } else {
+    const char* literal_buf = raw.ptr;
+    char* stored = arena_push(arena, raw.ptr, raw.len + 1);
+    if (!stored) {
+      if (literal_allocated) free((void*)raw.ptr);
+      return false;
+    }
+    stored[raw.len] = '\0';
+    atom.kind = GRAMMAR_ATOM_LITERAL;
+    atom.literal = str_from(stored, raw.len);
+    if (literal_allocated) {
+      free((void*)literal_buf);
+    }
+  }
+  *out_atom = atom;
+  return true;
+}
+
+static bool parse_production(const char* line,
+                             size_t len,
+                             InternTable* interns,
+                             Arena* arena,
+                             Production* prod) {
+  memset(prod, 0, sizeof(*prod));
+  while (true) {
+    const char* before = line;
+    size_t before_len = len;
+    GrammarAtom atom;
+    if (!parse_atom(&line, &len, interns, arena, &atom)) {
+      // No more atoms.
+      break;
+    }
+    if (!ensure_atom_capacity(prod)) {
+      free(prod->atoms);
+      return false;
+    }
+    prod->atoms[prod->atom_count++] = atom;
+    if (line == before && len == before_len) break;
+  }
+  return true;
+}
+
+static bool parse_rule_line(const char* line,
+                            size_t len,
+                            Grammar* grammar,
+                            InternTable* interns,
+                            Arena* arena) {
+  trim_whitespace(&line, &len);
+  if (len == 0 || line[0] == '#') return true;
+
+  size_t name_len = 0;
+  while (name_len < len && !isspace((unsigned char)line[name_len])) {
+    name_len++;
+  }
+  if (name_len == 0) return false;
+  Str name = str_from(line, name_len);
+  line += name_len;
+  len -= name_len;
+  trim_whitespace(&line, &len);
+
+  if (len < 2 || !(line[0] == ':' || line[0] == '+') || line[1] != '=') {
+    return false;
+  }
+  char op = line[0];
+  line += 2;
+  len -= 2;
+
+  GrammarRule* rule = find_or_add_rule(grammar, interns_intern(interns, name));
+  if (!rule) return false;
+  if (op == ':') {
+    reset_rule(rule);
+    rule->name = interns_intern(interns, name);
+  }
+
+  if (!ensure_production_capacity(rule)) return false;
+  Production* prod = &rule->productions[rule->production_count++];
+  if (!parse_production(line, len, interns, arena, prod)) return false;
+  return true;
+}
+
+bool grammar_load_file(Grammar* grammar,
+                       const char* path,
+                       InternTable* interns,
+                       Arena* arena) {
+  if (!grammar || !interns || !arena) return false;
+  memset(grammar, 0, sizeof(*grammar));
+  grammar->names = interns;
+
+  char* contents = NULL;
+  size_t len = 0;
+  if (!file_read_all(path, &contents, &len)) {
+    return false;
+  }
+
+  const char* cursor = contents;
+  while (len > 0) {
+    const char* line = cursor;
+    size_t line_len = 0;
+    while (line_len < len && cursor[line_len] != '\n') {
+      line_len++;
+    }
+    cursor += line_len + (line_len < len);
+    len -= line_len + (line_len < len);
+
+    if (!parse_rule_line(line, line_len, grammar, interns, arena)) {
+      free(contents);
+      grammar_free(grammar);
+      return false;
+    }
+  }
+
+  free(contents);
+  return grammar->rule_count > 0;
+}
+
+void grammar_free(Grammar* grammar) {
+  if (!grammar) return;
+  for (size_t i = 0; i < grammar->rule_count; ++i) {
+    reset_rule(&grammar->rules[i]);
+  }
+  free(grammar->rules);
+  grammar->rules = NULL;
+  grammar->rule_count = grammar->rule_cap = 0;
+  grammar->start_rule = 0;
+  grammar->names = NULL;
+}
+
+static GrammarRule* find_rule(const Grammar* grammar, Sym name) {
+  for (size_t i = 0; i < grammar->rule_count; ++i) {
+    if (grammar->rules[i].name == name) return &grammar->rules[i];
+  }
+  return NULL;
+}
+
+static bool match_atom(const Grammar* grammar,
+                       const GrammarAtom* atom,
+                       const struct token* tokens,
+                       size_t token_count,
+                       size_t* cursor,
+                       size_t depth);
+
+static bool match_production(const Grammar* grammar,
+                             const Production* prod,
+                             const struct token* tokens,
+                             size_t token_count,
+                             size_t* cursor,
+                             size_t depth) {
+  size_t local_cursor = *cursor;
+  for (size_t i = 0; i < prod->atom_count; ++i) {
+    if (!match_atom(grammar, &prod->atoms[i], tokens, token_count, &local_cursor, depth)) {
+      return false;
+    }
+  }
+  *cursor = local_cursor;
+  return true;
+}
+
+static bool match_rule(const Grammar* grammar,
+                       const GrammarRule* rule,
+                       const struct token* tokens,
+                       size_t token_count,
+                       size_t* cursor,
+                       size_t depth) {
+  if (depth > PARSER_MAX_DEPTH) return false;
+  for (size_t i = 0; i < rule->production_count; ++i) {
+    size_t local_cursor = *cursor;
+    if (match_production(grammar, &rule->productions[i], tokens, token_count, &local_cursor, depth + 1)) {
+      *cursor = local_cursor;
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool match_atom(const Grammar* grammar,
+                       const GrammarAtom* atom,
+                       const struct token* tokens,
+                       size_t token_count,
+                       size_t* cursor,
+                       size_t depth) {
+  if (atom->kind == GRAMMAR_ATOM_LITERAL) {
+    if (*cursor >= token_count) return false;
+    Str lexeme = tokens[*cursor].lexeme;
+    if (!str_eq(lexeme, atom->literal)) return false;
+    (*cursor)++;
+    return true;
+  }
+  if (atom->kind == GRAMMAR_ATOM_TOKEN_KIND) {
+    if (*cursor >= token_count) return false;
+    if (tokens[*cursor].kind != atom->symbol) return false;
+    (*cursor)++;
+    return true;
+  }
+  GrammarRule* rule = find_rule(grammar, atom->symbol);
+  if (!rule) return false;
+  return match_rule(grammar, rule, tokens, token_count, cursor, depth + 1);
+}
+
+bool grammar_parse(const Grammar* grammar,
+                   Sym start_rule,
+                   const struct token* tokens,
+                   size_t token_count) {
+  if (!grammar || grammar->rule_count == 0) return false;
+  size_t parse_count = token_count;
+  Sym eof_sym = interns_intern(grammar->names,
+                               str_from(LEXER_KIND_EOF, strlen(LEXER_KIND_EOF)));
+  if (parse_count > 0 && tokens[parse_count - 1].kind == eof_sym) {
+    parse_count--;
+  }
+  Sym start = start_rule ? start_rule : grammar->start_rule;
+  GrammarRule* rule = find_rule(grammar, start);
+  if (!rule) return false;
+  size_t cursor = 0;
+  if (!match_rule(grammar, rule, tokens, parse_count, &cursor, 0)) return false;
+  return cursor == parse_count;
+}


### PR DESCRIPTION
## Summary
- add a dynamic grammar loader and parser that support rule references and token-kind matches
- switch the lexer to static tokenization and update the CLI to drive parsing with grammar files
- provide an example grammar plus refreshed documentation for the new workflow

## Testing
- cmake -S . -B build
- cmake --build build
- ./build/src/morphlc examples/grammar.txt examples/program.src


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692661d3aa90832f9dc5fd7e515ba0dd)