### PR TITLE
Add reference/ident/forward typing support, fix builtin registration, and add tests

### DIFF
--- a/include/typing/type_context.h
+++ b/include/typing/type_context.h
@@ -12,6 +12,13 @@ typedef struct {
   MorphlType* type;
 } TypeEntry;
 
+// Forward declaration entry
+typedef struct {
+  Sym name;
+  MorphlType* type;
+  bool resolved;
+} ForwardEntry;
+
 // Variable entry in symbol table
 typedef struct {
   Sym name;
@@ -23,6 +30,10 @@ typedef struct {
   VarEntry* vars;
   size_t var_count;
   size_t var_capacity;
+  ForwardEntry* forwards;
+  size_t forward_count;
+  size_t forward_capacity;
+  bool has_forward_errors;
 } Scope;
 
 // Type checking context
@@ -42,6 +53,14 @@ typedef struct {
   
   // Current expected return type (set when checking function body)
   MorphlType* expected_return_type;
+
+  // Special scope bindings
+  MorphlType* file_type;
+  MorphlType* global_type;
+
+  MorphlType** this_stack;
+  size_t this_depth;
+  size_t this_capacity;
 } TypeContext;
 
 // Create/destroy TypeContext
@@ -60,6 +79,19 @@ bool type_context_check_duplicate_var(TypeContext* ctx, Sym name);
 // Function registry
 bool type_context_define_func(TypeContext* ctx, Sym name, MorphlType* func_type);
 MorphlType* type_context_lookup_func(TypeContext* ctx, Sym name);
+
+// Forward declarations
+bool type_context_define_forward(TypeContext* ctx, Sym name, MorphlType* func_type);
+bool type_context_define_forward_body(TypeContext* ctx, Sym name, MorphlType* func_type);
+ForwardEntry* type_context_lookup_forward(TypeContext* ctx, Sym name);
+bool type_context_check_unresolved_forwards(TypeContext* ctx);
+
+// Special scope bindings
+bool type_context_push_this(TypeContext* ctx, MorphlType* this_type);
+bool type_context_pop_this(TypeContext* ctx);
+MorphlType* type_context_get_this(TypeContext* ctx);
+MorphlType* type_context_get_file(TypeContext* ctx);
+MorphlType* type_context_get_global(TypeContext* ctx);
 
 // Return type management
 void type_context_set_return_type(TypeContext* ctx, MorphlType* ret_type);

--- a/include/typing/typing.h
+++ b/include/typing/typing.h
@@ -12,8 +12,10 @@ typedef enum {
   MORPHL_TYPE_INT,
   MORPHL_TYPE_FLOAT,
   MORPHL_TYPE_STRING,
+  MORPHL_TYPE_IDENT,
   MORPHL_TYPE_BOOL,
   MORPHL_TYPE_FUNC,      // Function type with parameters and return type
+  MORPHL_TYPE_REF,       // Reference type with mutability/inline flags
   MORPHL_TYPE_PRIMITIVE, // Legacy: generic primitive
   MORPHL_TYPE_BLOCK,     // Legacy: generic block
   MORPHL_TYPE_GROUP,     // Legacy: generic group
@@ -43,6 +45,13 @@ typedef struct {
   size_t field_count;
 } MorphlBlockType;
 
+// Reference type metadata
+typedef struct {
+  MorphlType* target;
+  bool is_mutable;
+  bool is_inline;
+} MorphlRefType;
+
 // Main type structure
 typedef struct MorphlType {
   MorphlTypeKind kind;
@@ -52,6 +61,7 @@ typedef struct MorphlType {
     MorphlFuncType func;    // kind == MORPHL_TYPE_FUNC
     MorphlGroupType group;  // kind == MORPHL_TYPE_GROUP
     MorphlBlockType block;  // kind == MORPHL_TYPE_BLOCK
+    MorphlRefType ref;       // kind == MORPHL_TYPE_REF
     Sym sym;                // Used for named types (traits, structs, etc.)
   } data;
   void* details;      // For future extensibility
@@ -63,10 +73,15 @@ MorphlType* morphl_type_void(Arena* arena);
 MorphlType* morphl_type_int(Arena* arena);
 MorphlType* morphl_type_float(Arena* arena);
 MorphlType* morphl_type_string(Arena* arena);
+MorphlType* morphl_type_ident(Arena* arena);
 MorphlType* morphl_type_bool(Arena* arena);
 MorphlType* morphl_type_func(Arena* arena,
                              MorphlType* param_type,
                              MorphlType* return_type);
+MorphlType* morphl_type_ref(Arena* arena,
+                            MorphlType* target,
+                            bool is_mutable,
+                            bool is_inline);
 MorphlType* morphl_type_group(Arena* arena,
                               MorphlType** elem_types,
                               size_t elem_count);

--- a/src/parser/operators.c
+++ b/src/parser/operators.c
@@ -132,7 +132,7 @@ static MorphlType* pp_action_call(const OperatorInfo* info,
   // Functions should have exactly 1 parameter
   if (func_type->data.func.param_count != 1) {
     MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$call: expected 1 parameter, function has %llu",
-           func_type->data.func.param_count);
+           (unsigned long long)func_type->data.func.param_count);
     morphl_error_emit(NULL, &err);
     return NULL;
   }
@@ -377,6 +377,20 @@ static MorphlType* pp_action_set(const OperatorInfo* info,
     return NULL;
   }
   
+  if (target_type && target_type->kind == MORPHL_TYPE_REF) {
+    if (!target_type->data.ref.is_mutable) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: target is not mutable");
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    if (!morphl_type_equals(target_type->data.ref.target, value_type)) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: type mismatch in assignment");
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    return value_type;
+  }
+
   // Check type compatibility
   if (!morphl_type_equals(target_type, value_type)) {
     MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: type mismatch in assignment");
@@ -518,8 +532,15 @@ static OperatorRow kBuiltinOps[] = {
   {"$decl",   AST_DECL,   true,  2, 2,          pp_action_decl,    0, OP_PP_KEEP_NODE},
   {"$ret",    AST_BUILTIN,false, 1, 1,          pp_action_ret,     0, OP_PP_KEEP_NODE},
   {"$member", AST_BUILTIN, false, 2, 2,         pp_action_member,  0, OP_PP_KEEP_NODE},
-  {"$ret",    AST_BUILTIN, false, 1, 1,         NULL,              0, OP_PP_KEEP_NODE},
-  {"$while",  AST_BUILTIN, false, 2, 2,         NULL,              0, OP_PP_KEEP_NODE},
+  {"$mut",    AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$const",  AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$inline", AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$this",   AST_BUILTIN,false, 0, 0,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$file",   AST_BUILTIN,false, 0, 0,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$global", AST_BUILTIN,false, 0, 0,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$idtstr", AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$strtid", AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
+  {"$forward",AST_BUILTIN,false, 1, 1,          NULL,              0, OP_PP_KEEP_NODE},
   {"$break",  AST_BUILTIN, false, 0, 0,         NULL,              0, OP_PP_KEEP_NODE},
   {"$continue",AST_BUILTIN,false, 0, 0,         NULL,              0, OP_PP_KEEP_NODE},
 

--- a/src/parser/scoped_parser.c
+++ b/src/parser/scoped_parser.c
@@ -386,6 +386,7 @@ bool scoped_parse_ast(ScopedParserContext* ctx,
   
   // Perform typing pass on the entire AST
   typing_pass_ast(ctx->type_context, *out_root);
+  (void)type_context_check_unresolved_forwards(ctx->type_context);
   
   return true;
 }

--- a/src/typing/inference.c
+++ b/src/typing/inference.c
@@ -2,6 +2,7 @@
 #include "parser/operators.h"
 #include "ast/ast.h"
 #include "util/error.h"
+#include "util/util.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,6 +19,13 @@ static const char* op_name_str(Sym op_sym, InternTable* interns) {
   if (!op_sym || !interns) return "<unknown>";
   Str op_name = interns_lookup(interns, op_sym);
   return op_name.ptr;
+}
+
+static MorphlType* unwrap_ref(MorphlType* t) {
+  while (t && t->kind == MORPHL_TYPE_REF && t->data.ref.target) {
+    t = t->data.ref.target;
+  }
+  return t;
 }
 
 MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
@@ -41,6 +49,70 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
   }
   
   // Type inference by operator kind
+  if (op_sym == interns_intern(ctx->interns, str_from("$mut", 4)) ||
+      op_sym == interns_intern(ctx->interns, str_from("$const", 6)) ||
+      op_sym == interns_intern(ctx->interns, str_from("$inline", 7))) {
+    if (arg_count != 1) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s expects 1 arg, got %llu", op_name, (unsigned long long)arg_count);
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    if (!arg_types[0]) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: cannot infer argument type", op_name);
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    bool is_mutable = op_sym == interns_intern(ctx->interns, str_from("$mut", 4));
+    bool is_inline = op_sym == interns_intern(ctx->interns, str_from("$inline", 7));
+    return morphl_type_ref(ctx->arena, arg_types[0], is_mutable, is_inline);
+  }
+
+  if (op_sym == interns_intern(ctx->interns, str_from("$this", 5))) {
+    MorphlType* this_type = type_context_get_this(ctx);
+    if (!this_type) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$this: no active block scope");
+      morphl_error_emit(NULL, &err);
+    }
+    return this_type;
+  }
+
+  if (op_sym == interns_intern(ctx->interns, str_from("$file", 5))) {
+    MorphlType* file_type = type_context_get_file(ctx);
+    if (!file_type) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$file: file scope unavailable");
+      morphl_error_emit(NULL, &err);
+    }
+    return file_type;
+  }
+
+  if (op_sym == interns_intern(ctx->interns, str_from("$global", 7))) {
+    MorphlType* global_type = type_context_get_global(ctx);
+    if (!global_type) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$global: global scope unavailable");
+      morphl_error_emit(NULL, &err);
+    }
+    return global_type;
+  }
+
+  if (op_sym == interns_intern(ctx->interns, str_from("$forward", 8))) {
+    if (arg_count != 1) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward expects 1 arg, got %llu", (unsigned long long)arg_count);
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    if (!arg_types[0]) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: cannot infer stub type");
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    if (arg_types[0]->kind != MORPHL_TYPE_FUNC) {
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: stub must be a function");
+      morphl_error_emit(NULL, &err);
+      return NULL;
+    }
+    return arg_types[0];
+  }
+
   // Comparison operators: (any, any) → bool
   if (op_sym == interns_intern(ctx->interns, str_from("$eq", 3)) ||
       op_sym == interns_intern(ctx->interns, str_from("$neq", 4)) ||
@@ -55,7 +127,9 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
       return NULL;
     }
     
-    if (!types_comparable(arg_types[0], arg_types[1])) {
+    MorphlType* left = unwrap_ref(arg_types[0]);
+    MorphlType* right = unwrap_ref(arg_types[1]);
+    if (!types_comparable(left, right)) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: types not compatible", op_name);
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -75,7 +149,8 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
     }
     
     for (size_t i = 0; i < 2; ++i) {
-      if (!arg_types[i] || arg_types[i]->kind != MORPHL_TYPE_BOOL) {
+      MorphlType* check = unwrap_ref(arg_types[i]);
+      if (!check || check->kind != MORPHL_TYPE_BOOL) {
         MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: arg %llu must be bool", op_name, (unsigned long long)(i + 1));
         morphl_error_emit(NULL, &err);
         return NULL;
@@ -87,12 +162,14 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
   
   if (op_sym == interns_intern(ctx->interns, str_from("$not", 4))) {
     if (arg_count != 1) {
-      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$not expects 1 arg, got %llu", arg_count);
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$not expects 1 arg, got %llu",
+                                   (unsigned long long)arg_count);
       morphl_error_emit(NULL, &err);
       return NULL;
     }
     
-    if (!arg_types[0] || arg_types[0]->kind != MORPHL_TYPE_BOOL) {
+    MorphlType* check = unwrap_ref(arg_types[0]);
+    if (!check || check->kind != MORPHL_TYPE_BOOL) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$not: argument must be bool");
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -114,8 +191,10 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
       return NULL;
     }
     
-    if (!arg_types[0] || arg_types[0]->kind != MORPHL_TYPE_INT ||
-        !arg_types[1] || arg_types[1]->kind != MORPHL_TYPE_INT) {
+    MorphlType* left = unwrap_ref(arg_types[0]);
+    MorphlType* right = unwrap_ref(arg_types[1]);
+    if (!left || left->kind != MORPHL_TYPE_INT ||
+        !right || right->kind != MORPHL_TYPE_INT) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: both arguments must be int", op_name);
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -136,8 +215,10 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
       return NULL;
     }
     
-    if (!arg_types[0] || arg_types[0]->kind != MORPHL_TYPE_FLOAT ||
-        !arg_types[1] || arg_types[1]->kind != MORPHL_TYPE_FLOAT) {
+    MorphlType* left = unwrap_ref(arg_types[0]);
+    MorphlType* right = unwrap_ref(arg_types[1]);
+    if (!left || left->kind != MORPHL_TYPE_FLOAT ||
+        !right || right->kind != MORPHL_TYPE_FLOAT) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: both arguments must be float", op_name);
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -159,8 +240,10 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
       return NULL;
     }
     
-    if (!arg_types[0] || arg_types[0]->kind != MORPHL_TYPE_INT ||
-        !arg_types[1] || arg_types[1]->kind != MORPHL_TYPE_INT) {
+    MorphlType* left = unwrap_ref(arg_types[0]);
+    MorphlType* right = unwrap_ref(arg_types[1]);
+    if (!left || left->kind != MORPHL_TYPE_INT ||
+        !right || right->kind != MORPHL_TYPE_INT) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "%s: both arguments must be int", op_name);
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -171,12 +254,14 @@ MorphlType* morphl_infer_type_for_op(TypeContext* ctx,
   
   if (op_sym == interns_intern(ctx->interns, str_from("$bnot", 5))) {
     if (arg_count != 1) {
-      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$bnot expects 1 arg, got %llu", arg_count);
+      MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$bnot expects 1 arg, got %llu",
+                                   (unsigned long long)arg_count);
       morphl_error_emit(NULL, &err);
       return NULL;
     }
     
-    if (!arg_types[0] || arg_types[0]->kind != MORPHL_TYPE_INT) {
+    MorphlType* check = unwrap_ref(arg_types[0]);
+    if (!check || check->kind != MORPHL_TYPE_INT) {
       MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$bnot: argument must be int");
       morphl_error_emit(NULL, &err);
       return NULL;
@@ -236,9 +321,62 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
       if (!name_node || name_node->kind != AST_IDENT || !name_node->op) return NULL;
       Sym var_sym = name_node->op;
       if (!init_node) return NULL;
+      Sym forward_sym = interns_intern(ctx->interns, str_from("$forward", 8));
+      if (init_node->kind == AST_BUILTIN && init_node->op == forward_sym) {
+        if (init_node->child_count != 1) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: expected 1 stub expression");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        AstNode* stub_node = init_node->children[0];
+        MorphlType* stub_type = morphl_infer_type_of_ast(ctx, stub_node);
+        if (!stub_type || stub_type->kind != MORPHL_TYPE_FUNC) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: stub must be a function");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        if (type_context_check_duplicate_var(ctx, var_sym)) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: variable already declared");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        if (!type_context_define_forward(ctx, var_sym, stub_type)) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: duplicate stub in scope");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        type_context_define_var(ctx, var_sym, stub_type);
+        type_context_define_func(ctx, var_sym, stub_type);
+        return stub_type;
+      }
+
+      if (init_node->kind == AST_FUNC ||
+          (init_node->kind == AST_BUILTIN && init_node->op &&
+           strcmp(op_name_str(init_node->op, ctx->interns), "$func") == 0)) {
+        MorphlType* placeholder = morphl_type_func(ctx->arena,
+                                                  morphl_type_unknown(ctx->arena),
+                                                  morphl_type_unknown(ctx->arena));
+        type_context_define_func(ctx, var_sym, placeholder);
+        type_context_define_var(ctx, var_sym, placeholder);
+      }
+
       MorphlType* init_type = morphl_infer_type_of_ast(ctx, init_node);
       if (!init_type) {
         MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$decl: cannot infer variable type");
+        morphl_error_emit(NULL, &err);
+        return NULL;
+      }
+
+      ForwardEntry* forward = type_context_lookup_forward(ctx, var_sym);
+      if (forward && !forward->resolved) {
+        if (!type_context_define_forward_body(ctx, var_sym, init_type)) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: definition mismatch for stub");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        return init_type;
+      } else if (forward && forward->resolved) {
+        MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$forward: multiple bodies for stub");
         morphl_error_emit(NULL, &err);
         return NULL;
       }
@@ -276,6 +414,17 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
 
     case AST_BLOCK: {
       if (!type_context_push_scope(ctx)) return NULL;
+      MorphlType* block_type = morphl_type_block(ctx->arena, NULL, NULL, 0);
+      if (!block_type || !type_context_push_this(ctx, block_type)) {
+        type_context_pop_scope(ctx);
+        return NULL;
+      }
+      if (!ctx->file_type) {
+        ctx->file_type = block_type;
+      }
+      if (!ctx->global_type) {
+        ctx->global_type = block_type;
+      }
       Sym* field_names = NULL;
       MorphlType** field_types = NULL;
       size_t field_count = 0;
@@ -300,16 +449,21 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
           field_names[field_count] = name_node->op;
           field_types[field_count] = stmt_type;
           field_count++;
+          Sym* names = (Sym*)arena_push(ctx->arena, NULL, field_count * sizeof(Sym));
+          MorphlType** types = (MorphlType**)arena_push(ctx->arena, NULL, field_count * sizeof(MorphlType*));
+          if (!names || !types) { ok = false; break; }
+          memcpy(names, field_names, field_count * sizeof(Sym));
+          memcpy(types, field_types, field_count * sizeof(MorphlType*));
+          block_type->data.block.field_names = names;
+          block_type->data.block.field_types = types;
+          block_type->data.block.field_count = field_count;
         }
       }
+      type_context_pop_this(ctx);
       type_context_pop_scope(ctx);
-      MorphlType* block_type = NULL;
-      if (ok) {
-        block_type = morphl_type_block(ctx->arena, field_names, field_types, field_count);
-      }
       free(field_names);
       free(field_types);
-      return block_type;
+      return ok ? block_type : NULL;
     }
 
     case AST_BUILTIN:
@@ -317,6 +471,103 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
     case AST_FUNC:
     case AST_IF:
     case AST_SET: {
+      if (!node->op) return NULL;
+      Sym idtstr_sym = interns_intern(ctx->interns, str_from("$idtstr", 7));
+      Sym strtid_sym = interns_intern(ctx->interns, str_from("$strtid", 7));
+      Sym member_sym = interns_intern(ctx->interns, str_from("$member", 7));
+      Sym set_sym = interns_intern(ctx->interns, str_from("$set", 4));
+      if (node->op == idtstr_sym) {
+        if (node->child_count != 1) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$idtstr expects 1 arg");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        AstNode* arg = node->children[0];
+        if (!arg || arg->kind != AST_IDENT) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$idtstr expects identifier");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        return morphl_type_string(ctx->arena);
+      }
+      if (node->op == strtid_sym) {
+        if (node->child_count != 1) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$strtid expects 1 arg");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        AstNode* arg = node->children[0];
+        if (!arg || arg->kind != AST_LITERAL || arg->value.len < 2 ||
+            arg->value.ptr[0] != '"' || arg->value.ptr[arg->value.len - 1] != '"') {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$strtid expects string literal");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        return morphl_type_ident(ctx->arena);
+      }
+      if (node->op == member_sym) {
+        if (node->child_count != 2) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$member expects 2 args");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        AstNode* target = node->children[0];
+        AstNode* field_node = node->children[1];
+        if (!field_node || field_node->kind != AST_IDENT) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$member expects identifier field");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        MorphlType* target_type = morphl_infer_type_of_ast(ctx, target);
+        if (!target_type) return NULL;
+        target_type = unwrap_ref(target_type);
+        if (!target_type || target_type->kind != MORPHL_TYPE_BLOCK) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$member: target must be block");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        Sym field_sym = field_node->op;
+        if (!field_sym && field_node->value.ptr) {
+          field_sym = interns_intern(ctx->interns, field_node->value);
+        }
+        for (size_t i = 0; i < target_type->data.block.field_count; ++i) {
+          if (target_type->data.block.field_names[i] == field_sym) {
+            return target_type->data.block.field_types[i];
+          }
+        }
+        MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$member: field not found");
+        morphl_error_emit(NULL, &err);
+        return NULL;
+      }
+      if (node->op == set_sym) {
+        if (node->child_count != 2) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set expects 2 args");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        MorphlType* target_type = morphl_infer_type_of_ast(ctx, node->children[0]);
+        MorphlType* value_type = morphl_infer_type_of_ast(ctx, node->children[1]);
+        if (!target_type || !value_type) return NULL;
+        if (target_type->kind == MORPHL_TYPE_REF) {
+          if (!target_type->data.ref.is_mutable) {
+            MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: target is not mutable");
+            morphl_error_emit(NULL, &err);
+            return NULL;
+          }
+          if (!morphl_type_equals(target_type->data.ref.target, value_type)) {
+            MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: type mismatch in assignment");
+            morphl_error_emit(NULL, &err);
+            return NULL;
+          }
+          return value_type;
+        }
+        if (!morphl_type_equals(target_type, value_type)) {
+          MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "$set: type mismatch in assignment");
+          morphl_error_emit(NULL, &err);
+          return NULL;
+        }
+        return value_type;
+      }
       // Infer argument types recursively
       MorphlType** arg_types = NULL;
       size_t arg_count = node->child_count;
@@ -345,10 +596,14 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
     
     case AST_IDENT: {
       // Look up identifier in scope
-      if (!node->op) return NULL;
-      MorphlType* var_type = type_context_lookup_var(ctx, node->op);
+      Sym sym = node->op;
+      if (!sym && node->value.ptr) {
+        sym = interns_intern(ctx->interns, node->value);
+      }
+      if (!sym) return NULL;
+      MorphlType* var_type = type_context_lookup_var(ctx, sym);
       if (!var_type) {
-        Str name = interns_lookup(ctx->interns, node->op);
+        Str name = interns_lookup(ctx->interns, sym);
         MorphlError err = MORPHL_ERR(MORPHL_E_TYPE, "undefined variable '%.*s'", (int)name.len, name.ptr);
         morphl_error_emit(NULL, &err);
         return NULL;
@@ -360,6 +615,12 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, const AstNode* node) {
       // Infer type from literal value
       if (!node->value.ptr || node->value.len == 0) return morphl_type_void(ctx->arena);
       
+      if (node->value.len >= 2 &&
+          node->value.ptr[0] == '"' &&
+          node->value.ptr[node->value.len - 1] == '"') {
+        return morphl_type_string(ctx->arena);
+      }
+
       // Simple heuristic: if it looks like a number, assume int
       // (in a real implementation, check for . for float, quotes for string, etc.)
       bool has_dot = false;


### PR DESCRIPTION
### Motivation
- Represent reference-like storage with mutability and inline semantics so `$mut`, `$const`, and `$inline` can be typed and assigned to.
- Allow identifier↔string meta-operations to be checked at type time via `$idtstr` and `$strtid`.
- Support forward-declared function stubs and ensure forward bodies are validated against stubs.
- Expose special scope values (`$this`, `$file`, `$global`) to the type layer for scope-aware member lookups.

### Description
- Updated builtin operator registrations in `src/parser/operators.c` to remove duplicates and register ` $mut`, `$const`, `$inline`, `$this`, `$file`, `$global`, `$idtstr`, `$strtid`, and `$forward` and ensured `pp_action_*` logic integrates with the operator registry. 
- Extended the type system with `MORPHL_TYPE_IDENT` and `MORPHL_TYPE_REF` and added constructors `morphl_type_ident` and `morphl_type_ref` in `src/typing/typing.c`/`include/typing/typing.h`, plus clone/equality/to-string handling for refs. 
- Enhanced inference in `src/typing/inference.c` to `unwrap_ref` when checking operands, create reference types for `$mut`/`$const`/`$inline`, implement `$this`/`$file`/`$global` lookups, support `$idtstr`/`$strtid` conversions, and treat `$forward` stubs and `$decl` processing to register forward entries. 
- Added forward-declaration tracking, a `this` stack and file/global bindings in `include/typing/type_context.h` / `src/typing/type_context.c`, implemented `type_context_define_forward`, `type_context_define_forward_body`, `type_context_lookup_forward`, `type_context_check_unresolved_forwards`, and call unresolved-forward checks from `src/parser/scoped_parser.c`. 

### Testing
- Configured the project with `cmake -S . -B build` which completed successfully. 
- Built the project with `cmake --build build` which completed successfully. 
- Ran the typing unit tests with `./build/test/typing_tests` which executed the new `test_ref_meta_forward_ops` along with the existing suite and reported all tests passed. 
- Fixed format warnings in error paths (casts to `(unsigned long long)` for `%llu`) to avoid warnings-as-errors during the build and verified the build succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696177da1db8832f8c4c4835cf4b6a79)