### PR TITLE
Add float literal tests and clarify lexer docs

### DIFF
--- a/include/lexer/lexer.h
+++ b/include/lexer/lexer.h
@@ -8,6 +8,7 @@
 // Token kind constants
 extern const char* const LEXER_KIND_IDENT;
 extern const char* const LEXER_KIND_NUMBER;
+extern const char* const LEXER_KIND_FLOAT;
 extern const char* const LEXER_KIND_STRING;
 extern const char* const LEXER_KIND_SYMBOL;
 extern const char* const LEXER_KIND_EOF;
@@ -16,7 +17,7 @@ extern const char* const LEXER_KIND_EOF;
  * @brief Tokenize a source buffer using a static rule set.
  *
  * The lexer recognizes identifiers (`[A-Za-z_][A-Za-z0-9_]*`), decimal
- * numbers (`[0-9]+`), string literals (`"..."`), and punctuation sequences
+ * numbers (`[0-9]+`), float numbers (`[0-9]+\\.[0-9]+`), string literals (`"..."`), and punctuation sequences
  * (any run of non-whitespace characters that are not alphanumeric or an
  * underscore). Whitespace is ignored while tracking row/column positions.
  * An explicit EOF token is appended to every stream. All token kinds are
@@ -40,6 +41,8 @@ bool lexer_tokenize(const char* filename,
 ///@{
 extern const char* const LEXER_KIND_IDENT;   /**< Identifier token kind name. */
 extern const char* const LEXER_KIND_NUMBER;  /**< Number token kind name. */
+extern const char* const LEXER_KIND_FLOAT;   /**< Float token kind name. */
+extern const char* const LEXER_KIND_STRING;  /**< String token kind name. */
 extern const char* const LEXER_KIND_SYMBOL;  /**< Punctuation token kind name. */
 extern const char* const LEXER_KIND_EOF;     /**< End-of-file token kind name. */
 ///@}

--- a/src/typing/inference.c
+++ b/src/typing/inference.c
@@ -1,6 +1,7 @@
 #include "typing/inference.h"
 #include "parser/operators.h"
 #include "ast/ast.h"
+#include "lexer/lexer.h"
 #include "util/error.h"
 #include "util/util.h"
 #include <string.h>
@@ -624,6 +625,21 @@ MorphlType* morphl_infer_type_of_ast(TypeContext* ctx, AstNode* node) {
           node->value.ptr[0] == '"' &&
           node->value.ptr[node->value.len - 1] == '"') {
         return morphl_type_string(ctx->arena);
+      }
+
+      if (node->op) {
+        Sym number_kind = interns_intern(ctx->interns, str_from(LEXER_KIND_NUMBER, strlen(LEXER_KIND_NUMBER)));
+        Sym float_kind = interns_intern(ctx->interns, str_from(LEXER_KIND_FLOAT, strlen(LEXER_KIND_FLOAT)));
+        Sym string_kind = interns_intern(ctx->interns, str_from(LEXER_KIND_STRING, strlen(LEXER_KIND_STRING)));
+        if (string_kind && node->op == string_kind) {
+          return morphl_type_string(ctx->arena);
+        }
+        if (float_kind && node->op == float_kind) {
+          return morphl_type_float(ctx->arena);
+        }
+        if (number_kind && node->op == number_kind) {
+          return morphl_type_int(ctx->arena);
+        }
       }
 
       // Simple heuristic: if it looks like a number, assume int

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -174,10 +174,49 @@ end
   std::remove(grammar_path.c_str());
 }
 
+static void test_float_literal_token_kind() {
+  const char* grammar_src = R"GRAM(rule expr:
+    %NUMBER => number
+end
+)GRAM";
+
+  std::string grammar_path = write_temp_file(grammar_src);
+
+  InternTable* interns = interns_new();
+  assert(interns != nullptr);
+
+  Arena arena;
+  arena_init(&arena, 4096);
+
+  Grammar grammar;
+  assert(grammar_load_file(&grammar, grammar_path.c_str(), interns, &arena));
+
+  const char* source = "3.14";
+  struct token* tokens = NULL;
+  size_t token_count = 0;
+  assert(lexer_tokenize("<test>", str_from(source, strlen(source)), interns, &tokens, &token_count));
+
+  AstNode* root = NULL;
+  assert(grammar_parse_ast(&grammar, 0, tokens, token_count, &root));
+  assert(root != NULL);
+  assert(root->kind == AST_LITERAL);
+
+  Sym float_sym = interns_intern(interns, str_from(LEXER_KIND_FLOAT, strlen(LEXER_KIND_FLOAT)));
+  assert(root->op == float_sym);
+
+  ast_free(root);
+  free(tokens);
+  grammar_free(&grammar);
+  arena_free(&arena);
+  interns_free(interns);
+  std::remove(grammar_path.c_str());
+}
+
 int main() {
   test_grammar_loading();
   test_parser_accept_reject();
   test_parser_ast_build();
+  test_float_literal_token_kind();
   std::puts("All parser tests passed.");
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Distinguish decimal `FLOAT` literals from integer `NUMBER` tokens so parsing and typing can rely on lexer classification.
- Preserve the lexer-provided token kind inside AST literal nodes so inference can use a canonical source of truth rather than heuristics.
- Ensure quoted strings are recognized as `STRING` token kind and yield `MORPHL_TYPE_STRING` in inference.
- Add tests to validate parsing classification and typing behavior for int/float/string literals.

### Description
- Clarified lexer docs and added `LEXER_KIND_FLOAT`/`LEXER_KIND_STRING` declarations in `include/lexer/lexer.h`.
- Updated `src/lexer/lexer.c` to intern a `FLOAT` kind and emit `FLOAT` tokens when a fractional part is present.
- Modified `src/parser/builtin_parser.c` and `src/parser/parser.c` to accept `FLOAT` as a literal kind, to accept `FLOAT` when a grammar expects `%NUMBER`, and to store the token kind on literal AST nodes via `node->op`.
- Enhanced `src/typing/inference.c` to consult `node->op` (interned `NUMBER`/`FLOAT`/`STRING`) when inferring literal types, and added tests in `test/parser_tests.cpp` and `test/typing_tests.cpp` to cover the new behavior.

### Testing
- Ran `cmake -S . -B build` and configuration completed successfully.
- Ran `cmake --build build` and the project built successfully.
- Ran `ctest --test-dir build` and all tests passed (`parser_tests`, `error_tests`, `typing_tests`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961e7fc9b28832fab689b01044e4067)