### PR TITLE
Support $import parsing into module ASTs, intern decl identifiers, and add typing test

### DIFF
--- a/include/typing/type_context.h
+++ b/include/typing/type_context.h
@@ -57,6 +57,12 @@ typedef struct {
   // Special scope bindings
   MorphlType* file_type;
   MorphlType* global_type;
+  MorphlType** file_stack;
+  size_t file_depth;
+  size_t file_capacity;
+  MorphlType** global_stack;
+  size_t global_depth;
+  size_t global_capacity;
 
   MorphlType** this_stack;
   size_t this_depth;
@@ -90,6 +96,10 @@ bool type_context_check_unresolved_forwards(TypeContext* ctx);
 bool type_context_push_this(TypeContext* ctx, MorphlType* this_type);
 bool type_context_pop_this(TypeContext* ctx);
 MorphlType* type_context_get_this(TypeContext* ctx);
+bool type_context_push_file(TypeContext* ctx, MorphlType* file_type);
+bool type_context_pop_file(TypeContext* ctx);
+bool type_context_push_global(TypeContext* ctx, MorphlType* global_type);
+bool type_context_pop_global(TypeContext* ctx);
 MorphlType* type_context_get_file(TypeContext* ctx);
 MorphlType* type_context_get_global(TypeContext* ctx);
 


### PR DESCRIPTION
### Motivation
- Allow `$import` to read and parse a source file at preprocess time so imports provide module `AST_BLOCK`s for typing and later resolution.
- Ensure top-level `$decl` names in parsed modules are interned so block field collection and `$member` resolution can find them reliably.
- Provide isolated file/global bindings while inferring imported modules so nested parsing does not clobber the parent `TypeContext`.

### Description
- Implemented `$import` preprocessor action in `src/parser/operators.c` to read a file, tokenize it, parse it with a fresh `ScopedParserContext`, and replace the string argument with an `AST_BLOCK` module AST.
- Intern declaration identifiers during preprocessing and when collecting block fields so `AST_DECL` names get a `Sym` (changes in `src/parser/operators.c` and `src/typing/inference.c`).
- Added stack-based `file`/`global` bindings and push/pop APIs in `src/typing/type_context.c`/`include/typing/type_context.h` and used them while inferring imported module nodes.
- Added `test/typing_tests.cpp` coverage for `$import` producing a block of fields and validating `$member` access against imported module fields, plus a helper `write_temp_file` for tests.

### Testing
- Ran configuration and build with `cmake -S . -B build` and `cmake --build build`, which completed successfully.
- Ran the test suite with `ctest --test-dir build` and all tests passed (`3/3` tests passed).
- The new typing test `test_import_block_fields` is included in `test/typing_tests.cpp` and executed as part of the test run.
- Fixes were iteratively validated by rebuilding and rerunning the tests until the suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ebb35dd8832f8979e101b646488f)