### PR TITLE
Support $$ directives and overload tokens in template delegation

### DIFF
--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -79,8 +79,9 @@ typedef struct GrammarRule {
  * Omitting the square-bracket suffix defaults the binding power to zero.
  * Associativity is expressed by using different binding powers for left and
  * right operands of an operator.
- * The text after `=>` is captured as a template string for downstream
- * expansion; the parser does not interpret template contents directly.
+ * The text after `=>` is captured as a template string and expanded into a
+ * builtin-operator expression by substituting captures before delegating to
+ * the builtin parser.
  */
 typedef struct Grammar {
   GrammarRule* rules;      /**< Rule list. */

--- a/src/parser/operators.c
+++ b/src/parser/operators.c
@@ -586,6 +586,7 @@ static OperatorRow kBuiltinOps[] = {
   // Structural
   {"$group",  AST_GROUP,  false, 0, (size_t)-1, NULL,              0, OP_PP_KEEP_NODE},
   {"$block",  AST_BLOCK,  false, 0, (size_t)-1, NULL,              0, OP_PP_KEEP_NODE},
+  {"$overload", AST_OVERLOAD, false, 0, (size_t)-1, NULL,           0, OP_PP_KEEP_NODE},
 
   // Core constructs
   {"$call",   AST_CALL,   false, 2, 2,          pp_action_call,    0, OP_PP_KEEP_NODE},


### PR DESCRIPTION
### Motivation
- Template expansion delegates to the builtin parser, but compiler-directive tokens like `$$spread` were not being tokenized as builtin identifiers and thus could not be parsed by the builtin parser. 
- `AST_OVERLOAD` nodes produced during template substitution could not be round-tripped through the builtin parser because no `$overload` operator or fallback name existed. 
- Building temporary token streams for template expansion required helpers to reliably construct token arrays and clean them up on error paths. 

### Description
- Treat `$$`-prefixed tokens as identifier-kind tokens by updating `token_kind_for_text` to accept a second `$` and use `TokenKinds` when building template token streams. 
- Add `TokenBuffer`, `TokenKinds`, `ensure_token_capacity`, `intern_token_kinds`, `append_token`, `append_ast_tokens*`, and `append_capture_tokens` helpers and use them to assemble a token array (including an `eof` token) for templates. 
- Change `build_template_ast` to serialize template operator/capture contents into the token buffer and delegate parsing to `builtin_parse_ast`, temporarily prefixing bare operator names with `$` and restoring the original name on the resulting `AstNode`. 
- Add `$overload` to the builtin operator table and return `"$overload"` from `fallback_op_for_kind` so `AST_OVERLOAD` nodes can be serialized and parsed back correctly, and improve error-path cleanup for temporaries like `owned_op_text` and the token buffer. 

### Testing
- Built the project with `cmake --build build`, which succeeded. 
- Ran unit tests with `ctest --test-dir build`, and all tests passed (`3/3`). 
- Ran `./build/src/morphlc examples/grammar_sample.txt examples/program.src` to exercise template delegation and observed parsing succeed for previously failing cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f8b9ba50832f8ec3d511af917540)