### PR TITLE
Add minimal VM runtime, --run CLI, and V0.1 operator support

### DIFF
--- a/docs/backend/vm_bytecode.md
+++ b/docs/backend/vm_bytecode.md
@@ -58,6 +58,17 @@ The VM emitter treats compile-time operators as already resolved by the compiler
 - `$decl` is lowered to stack-oriented behavior: emit RHS value, then `SET_SLOT <name>`.
 - Runtime operators (e.g. `$add`, `$set`, `$call`, etc.) are emitted verbatim through `OPERATOR` with a string table index.
 
+## Runtime operator support (V0.1)
+
+The V0.1 runtime executes `OPERATOR` instructions by symbol name. Supported operators:
+
+- `$add`: pops two operands, resolves identifier operands through slot bindings, parses both as numeric literals, and pushes the numeric sum as a literal string.
+- `$set`: pops `(lhs, rhs)`, requires `lhs` to be an identifier, writes `rhs` into that slot, and pushes `rhs`.
+
+All other runtime operators fail with a clear error message:
+
+- `runtime error: unsupported operator '<name>' (supported in V0.1: $add, $set)`
+
 ## Example invocation
 
 ```bash

--- a/include/runtime/runtime.h
+++ b/include/runtime/runtime.h
@@ -1,153 +1,30 @@
 #ifndef MORPHL_RUNTIME_RUNTIME_H_
 #define MORPHL_RUNTIME_RUNTIME_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
-#include "util/util.h"
+typedef struct MorphlVmProgram MorphlVmProgram;
+typedef struct MorphlVm MorphlVm;
 
-// TODO: finish runtime definitions
+/// Load a MorphL VM bytecode program from disk (out.mbc format).
+bool morphl_vm_program_load(const char* path, MorphlVmProgram** out_program);
 
-// Primitive runtime types
-typedef enum {
-    MORPHL_VALUE_TYPE_INT,
-    MORPHL_VALUE_TYPE_FLOAT,
-    MORPHL_VALUE_TYPE_BOOL,
-    MORPHL_VALUE_TYPE_STRING,
-    MORPHL_VALUE_TYPE_VOID,
-    MORPHL_VALUE_TYPE_FUNC,
-    MORPHL_VALUE_TYPE_BLOCK,
-    MORPHL_VALUE_TYPE_GROUP,
-    MORPHL_VALUE_TYPE_UNKNOWN
-} MorphlValueType;
+/// Release memory associated with a loaded program.
+void morphl_vm_program_free(MorphlVmProgram* program);
 
+/// Build a VM instance that can execute the loaded program.
+MorphlVm* morphl_vm_new(const MorphlVmProgram* program);
 
+/// Destroy a VM instance.
+void morphl_vm_free(MorphlVm* vm);
 
-// VM structure
-typedef struct {
-    uint8_t* bytecode;
-    size_t bytecode_size;
-    size_t ip; // instruction pointer
-    uint8_t* stack; // stack memory
-    size_t stack_size;
-    size_t sp; // stack pointer
-    size_t fp; // frame pointer
-    /// @brief General purpose registers. always a reference type (i.e. pointer to value)
-    /// lreg should always be active (i.e. being the target for op like push/pop store/load etc).
-    /// rreg is secondary register that can be used for operations needing two registers. can be set via swapping with lreg. 
-    uintptr_t lreg, rreg;
-    size_t constant_offset; // constant pool offset
-} MorphlVM;
+/// Execute bytecode in the VM. Returns true on success, false on runtime error.
+bool morphl_vm_execute(MorphlVm* vm, FILE* err_stream);
 
-
-// VM operations
-typedef enum {
-    // halt the VM
-    MORPHL_VM_OP_HALT = 0,
-    // no operation
-    MORPHL_VM_OP_NOP,
-    /// @brief load effective address from sp into lreg
-    MORPHL_VM_OP_LEA,
-    /// @brief load effective address from stack offset into lreg, operand=size_t offset
-    MORPHL_VM_OP_LEA_OFFSET,
-    /// @brief load effective address from frame pointer offset into lreg, operand=size_t offset
-    MORPHL_VM_OP_LEA_FP_OFFSET,
-    /// @brief load effective address from constant pool into lreg, operand=size_t offset
-    MORPHL_VM_OP_LEA_CONST,
-    /// @brief load immediate 64-bit into scratch to which will be referenced by lreg
-    MORPHL_VM_OP_LDI64,
-    /// @brief load immediate 32-bit into scratch to which will be referenced by lreg
-    MORPHL_VM_OP_LDI32,
-    /// @brief load immediate 16-bit into scratch to which will be referenced by lreg
-    MORPHL_VM_OP_LDI16,
-    /// @brief load immediate 8-bit into scratch to which will be referenced by lreg
-    MORPHL_VM_OP_LDI8,
-    /// @brief push immediate 64-bit value onto stack
-    MORPHL_VM_OP_PUSHI64,
-    /// @brief push immediate 32-bit value onto stack
-    MORPHL_VM_OP_PUSHI32,
-    /// @brief push immediate 16-bit value onto stack
-    MORPHL_VM_OP_PUSHI16,
-    /// @brief push immediate 8-bit value onto stack
-    MORPHL_VM_OP_PUSHI8,
-    /// @brief push constant pool address onto stack, operand=size_t offset
-    MORPHL_VM_OP_PUSH_CONST,
-    /// @brief pop value from stack into lreg
-    MORPHL_VM_OP_POP,
-    /// @brief pop until stack offset, discarding values, operand=size_t offset
-    MORPHL_VM_OP_POPU,
-    // arithmetic operations
-    MORPHL_VM_OP_ADD,
-    MORPHL_VM_OP_SUB,
-    MORPHL_VM_OP_MUL,
-    MORPHL_VM_OP_DIV,
-    MORPHL_VM_OP_MOD,
-    // floating point operations
-    MORPHL_VM_OP_FADD,
-    MORPHL_VM_OP_FSUB,
-    MORPHL_VM_OP_FMUL,
-    MORPHL_VM_OP_FDIV,
-    // control flow
-    MORPHL_VM_OP_JMP,
-    MORPHL_VM_OP_JMP_IF_FALSE,
-    /// @brief call function operand=size of args lreg=func addr rreg=args
-    MORPHL_VM_OP_CALL,
-    // return from function
-    MORPHL_VM_OP_RET,
-    /// @brief load value from memory address into lreg
-    MORPHL_VM_OP_LOAD,
-    /// @brief load constant address into lreg, operand=const pool offset 
-    MORPHL_VM_OP_LOAD_CONST,
-    /// @brief store value from rreg into memory address in lreg
-    MORPHL_VM_OP_STORE,
-    // comparison operations
-    MORPHL_VM_OP_EQ,
-    MORPHL_VM_OP_NEQ,
-    MORPHL_VM_OP_LT,
-    MORPHL_VM_OP_GT,
-    MORPHL_VM_OP_LTE,
-    MORPHL_VM_OP_GTE,
-    // logical operations
-    MORPHL_VM_OP_AND,
-    MORPHL_VM_OP_OR,
-    MORPHL_VM_OP_NOT,
-    // bitwise operations
-    MORPHL_VM_OP_BAND,
-    MORPHL_VM_OP_BOR,
-    MORPHL_VM_OP_BXOR,
-    MORPHL_VM_OP_BNOT,
-    MORPHL_VM_OP_LSHIFT,
-    MORPHL_VM_OP_RSHIFT,
-    // register operations
-    /// @brief swap lreg and rreg
-    MORPHL_VM_OP_SWAP,
-    /// @brief copy value from rreg to lreg
-    MORPHL_VM_OP_COPY
-} MorphlVMOp;
-
-
-// Bytecode structure
-typedef struct {
-    // Magic number for identification
-    uint32_t magic;
-    // Version number
-    uint32_t version;
-    // Bytecode instructions
-    uint8_t* bytecode;
-    size_t bytecode_size; // Size of bytecode in bytes (excluding header, including constant pool)
-    // Constant pool
-    size_t constant_pool_offset; // Offset from start of bytecode to the constant pool
-    // Entry point
-    size_t entry_point;
-    // Metadata (Optional)
-} MorphlBytecode;
-
-// VM API
-MorphlVM* morphl_vm_new(size_t stack_size);
-void morphl_vm_free(MorphlVM* vm);
-
-int morphl_vm_execute(MorphlVM* vm);
-
-
+/// Convenience helper for load + execute + teardown.
+bool morphl_vm_run_file(const char* path, FILE* err_stream);
 
 #endif // MORPHL_RUNTIME_RUNTIME_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(morphlc
   morphl_ast
   morphl_util
   morphl_backend
+  morphl_runtime
 )
 
 add_subdirectory(util)
@@ -21,6 +22,4 @@ add_subdirectory(ast)
 add_subdirectory(typing)
 add_subdirectory(backend)
 
-
-
-
+add_subdirectory(runtime)

--- a/src/main.c
+++ b/src/main.c
@@ -7,41 +7,61 @@
 #include "parser/builtin_parser.h"
 #include "parser/scoped_parser.h"
 #include "parser/operators.h"
+#include "runtime/runtime.h"
 #include "util/file.h"
 #include "util/util.h"
 #include <backend/backend.h>
 
 int main(int argc, char** argv) {
   if (argc < 2) {
-    fprintf(stderr, "usage: %s [--backend c|vm] [grammar-file] <source-file>\n", argv[0]);
+    fprintf(stderr, "usage: %s [--backend c|vm] [--run] [grammar-file] <source-file>\n", argv[0]);
     fprintf(stderr, "  If grammar-file is omitted, uses builtin operators only.\n");
     fprintf(stderr, "  Use $syntax \"file\" directive within source to load custom grammars.\n");
     return 1;
   }
 
   enum MorphlBackendType backend_type = MORPHL_BACKEND_TYPE_C;
+  bool run_bytecode = false;
   int arg_index = 1;
-  if (argc > arg_index && strcmp(argv[arg_index], "--backend") == 0) {
-    if (argc <= arg_index + 1) {
-      fprintf(stderr, "missing backend value after --backend\n");
-      return 1;
+
+  while (argc > arg_index && strncmp(argv[arg_index], "--", 2) == 0) {
+    if (strcmp(argv[arg_index], "--backend") == 0) {
+      if (argc <= arg_index + 1) {
+        fprintf(stderr, "missing backend value after --backend\n");
+        return 1;
+      }
+
+      const char* backend_name = argv[arg_index + 1];
+      if (strcmp(backend_name, "c") == 0) {
+        backend_type = MORPHL_BACKEND_TYPE_C;
+      } else if (strcmp(backend_name, "vm") == 0) {
+        backend_type = MORPHL_BACKEND_TYPE_VM;
+      } else {
+        fprintf(stderr, "unknown backend '%s' (expected 'c' or 'vm')\n", backend_name);
+        return 1;
+      }
+      arg_index += 2;
+      continue;
     }
 
-    const char* backend_name = argv[arg_index + 1];
-    if (strcmp(backend_name, "c") == 0) {
-      backend_type = MORPHL_BACKEND_TYPE_C;
-    } else if (strcmp(backend_name, "vm") == 0) {
-      backend_type = MORPHL_BACKEND_TYPE_VM;
-    } else {
-      fprintf(stderr, "unknown backend '%s' (expected 'c' or 'vm')\n", backend_name);
-      return 1;
+    if (strcmp(argv[arg_index], "--run") == 0) {
+      run_bytecode = true;
+      arg_index += 1;
+      continue;
     }
-    arg_index += 2;
+
+    fprintf(stderr, "unknown option '%s'\n", argv[arg_index]);
+    return 1;
   }
 
   int remaining = argc - arg_index;
   if (remaining < 1 || remaining > 2) {
-    fprintf(stderr, "usage: %s [--backend c|vm] [grammar-file] <source-file>\n", argv[0]);
+    fprintf(stderr, "usage: %s [--backend c|vm] [--run] [grammar-file] <source-file>\n", argv[0]);
+    return 1;
+  }
+
+  if (run_bytecode && backend_type != MORPHL_BACKEND_TYPE_VM) {
+    fprintf(stderr, "--run is only supported with --backend vm\n");
     return 1;
   }
 
@@ -129,6 +149,15 @@ int main(int argc, char** argv) {
       accepted = false;
     } else if (morphl_compile(&backend_ctx)) {
       printf("backend code generation succeeded, output written to %s\n", backend_ctx.out_file);
+      if (run_bytecode) {
+        printf("executing VM bytecode from %s...\n", backend_ctx.out_file);
+        if (!morphl_vm_run_file(backend_ctx.out_file, stderr)) {
+          printf("VM execution failed\n");
+          accepted = false;
+        } else {
+          printf("VM execution succeeded\n");
+        }
+      }
     } else {
       printf("backend code generation failed\n");
       accepted = false;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(morphl_runtime
+  vm_runtime.c
+)
+
+target_include_directories(morphl_runtime PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/runtime/vm_runtime.c
+++ b/src/runtime/vm_runtime.c
@@ -1,0 +1,698 @@
+#include "runtime/runtime.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MORPHL_VM_MAGIC "MVMB"
+
+enum VmOpcode {
+    VM_OP_HALT = 0x00,
+    VM_OP_PUSH_NULL = 0x01,
+    VM_OP_PUSH_LITERAL = 0x02,
+    VM_OP_PUSH_IDENT = 0x03,
+    VM_OP_MAKE_GROUP = 0x04,
+    VM_OP_SET_SLOT = 0x05,
+    VM_OP_OPERATOR = 0x06,
+    VM_OP_NODE_META = 0x07,
+};
+
+typedef enum {
+    VM_VALUE_NULL,
+    VM_VALUE_LITERAL,
+    VM_VALUE_IDENT,
+    VM_VALUE_GROUP,
+} VmValueKind;
+
+typedef struct VmValue VmValue;
+
+struct VmValue {
+    VmValueKind kind;
+    char* text;
+    VmValue* items;
+    size_t item_count;
+};
+
+typedef struct {
+    char* name;
+    VmValue value;
+} VmSlot;
+
+struct MorphlVmProgram {
+    uint16_t version_major;
+    uint16_t version_minor;
+    char** strings;
+    uint32_t string_count;
+    uint8_t* code;
+    uint32_t code_len;
+};
+
+struct MorphlVm {
+    const MorphlVmProgram* program;
+    size_t ip;
+    VmValue* stack;
+    size_t stack_count;
+    size_t stack_capacity;
+    VmSlot* slots;
+    size_t slot_count;
+    size_t slot_capacity;
+};
+
+static void vm_value_free(VmValue* value) {
+    if (!value) {
+        return;
+    }
+    free(value->text);
+    value->text = NULL;
+    for (size_t i = 0; i < value->item_count; ++i) {
+        vm_value_free(&value->items[i]);
+    }
+    free(value->items);
+    value->items = NULL;
+    value->item_count = 0;
+    value->kind = VM_VALUE_NULL;
+}
+
+static bool vm_value_copy(const VmValue* src, VmValue* dst) {
+    memset(dst, 0, sizeof(*dst));
+    dst->kind = src->kind;
+
+    if (src->text) {
+        size_t n = strlen(src->text);
+        dst->text = malloc(n + 1);
+        if (!dst->text) {
+            return false;
+        }
+        memcpy(dst->text, src->text, n + 1);
+    }
+
+    if (src->item_count > 0) {
+        dst->items = calloc(src->item_count, sizeof(VmValue));
+        if (!dst->items) {
+            vm_value_free(dst);
+            return false;
+        }
+
+        for (size_t i = 0; i < src->item_count; ++i) {
+            if (!vm_value_copy(&src->items[i], &dst->items[i])) {
+                for (size_t j = 0; j < i; ++j) {
+                    vm_value_free(&dst->items[j]);
+                }
+                free(dst->items);
+                dst->items = NULL;
+                vm_value_free(dst);
+                return false;
+            }
+        }
+        dst->item_count = src->item_count;
+    }
+
+    return true;
+}
+
+static bool read_u16(const uint8_t* bytes, size_t len, size_t* off, uint16_t* out) {
+    if ((*off + 2) > len) {
+        return false;
+    }
+    *out = (uint16_t)(bytes[*off] | (uint16_t)(bytes[*off + 1] << 8));
+    *off += 2;
+    return true;
+}
+
+static bool read_u32(const uint8_t* bytes, size_t len, size_t* off, uint32_t* out) {
+    if ((*off + 4) > len) {
+        return false;
+    }
+    *out = (uint32_t)bytes[*off] |
+           ((uint32_t)bytes[*off + 1] << 8) |
+           ((uint32_t)bytes[*off + 2] << 16) |
+           ((uint32_t)bytes[*off + 3] << 24);
+    *off += 4;
+    return true;
+}
+
+static void report_error(FILE* err_stream, const char* message) {
+    FILE* out = err_stream ? err_stream : stderr;
+    fprintf(out, "runtime error: %s\n", message);
+}
+
+static const VmValue* vm_resolve_value(const MorphlVm* vm, const VmValue* value) {
+    if (value->kind != VM_VALUE_IDENT || !value->text) {
+        return value;
+    }
+
+    for (size_t i = 0; i < vm->slot_count; ++i) {
+        if (strcmp(vm->slots[i].name, value->text) == 0) {
+            return &vm->slots[i].value;
+        }
+    }
+
+    return value;
+}
+
+static bool vm_stack_push(MorphlVm* vm, const VmValue* value) {
+    if (vm->stack_count == vm->stack_capacity) {
+        size_t new_capacity = (vm->stack_capacity == 0) ? 16 : vm->stack_capacity * 2;
+        VmValue* grown = realloc(vm->stack, new_capacity * sizeof(VmValue));
+        if (!grown) {
+            return false;
+        }
+        vm->stack = grown;
+        vm->stack_capacity = new_capacity;
+    }
+
+    VmValue copy = {0};
+    if (!vm_value_copy(value, &copy)) {
+        return false;
+    }
+
+    vm->stack[vm->stack_count++] = copy;
+    return true;
+}
+
+static bool vm_stack_pop(MorphlVm* vm, VmValue* out) {
+    if (vm->stack_count == 0) {
+        return false;
+    }
+
+    *out = vm->stack[--vm->stack_count];
+    memset(&vm->stack[vm->stack_count], 0, sizeof(VmValue));
+    return true;
+}
+
+static bool vm_set_slot(MorphlVm* vm, const char* name, const VmValue* value) {
+    for (size_t i = 0; i < vm->slot_count; ++i) {
+        if (strcmp(vm->slots[i].name, name) == 0) {
+            vm_value_free(&vm->slots[i].value);
+            return vm_value_copy(value, &vm->slots[i].value);
+        }
+    }
+
+    if (vm->slot_count == vm->slot_capacity) {
+        size_t new_capacity = (vm->slot_capacity == 0) ? 16 : vm->slot_capacity * 2;
+        VmSlot* grown = realloc(vm->slots, new_capacity * sizeof(VmSlot));
+        if (!grown) {
+            return false;
+        }
+        vm->slots = grown;
+        vm->slot_capacity = new_capacity;
+    }
+
+    char* dup_name = malloc(strlen(name) + 1);
+    if (!dup_name) {
+        return false;
+    }
+    strcpy(dup_name, name);
+
+    VmValue copy = {0};
+    if (!vm_value_copy(value, &copy)) {
+        free(dup_name);
+        return false;
+    }
+
+    vm->slots[vm->slot_count].name = dup_name;
+    vm->slots[vm->slot_count].value = copy;
+    vm->slot_count++;
+    return true;
+}
+
+static bool vm_value_to_number(const VmValue* value, double* out_num) {
+    if (!value || value->kind != VM_VALUE_LITERAL || !value->text) {
+        return false;
+    }
+
+    char* end = NULL;
+    errno = 0;
+    double parsed = strtod(value->text, &end);
+    if (errno != 0 || end == value->text || *end != '\0') {
+        return false;
+    }
+
+    *out_num = parsed;
+    return true;
+}
+
+static bool vm_execute_operator(MorphlVm* vm, const char* op_name, FILE* err_stream) {
+    if (strcmp(op_name, "$add") == 0) {
+        VmValue rhs = {0};
+        VmValue lhs = {0};
+        if (!vm_stack_pop(vm, &rhs) || !vm_stack_pop(vm, &lhs)) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "$add requires two operands");
+            return false;
+        }
+
+        const VmValue* lhs_resolved = vm_resolve_value(vm, &lhs);
+        const VmValue* rhs_resolved = vm_resolve_value(vm, &rhs);
+
+        double lhs_num = 0;
+        double rhs_num = 0;
+        if (!vm_value_to_number(lhs_resolved, &lhs_num) || !vm_value_to_number(rhs_resolved, &rhs_num)) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "$add currently supports numeric literal operands only");
+            return false;
+        }
+
+        char buffer[64];
+        int written = snprintf(buffer, sizeof(buffer), "%.17g", lhs_num + rhs_num);
+        if (written <= 0 || (size_t)written >= sizeof(buffer)) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "failed to format $add result");
+            return false;
+        }
+
+        VmValue result = {
+            .kind = VM_VALUE_LITERAL,
+            .text = malloc((size_t)written + 1),
+            .items = NULL,
+            .item_count = 0,
+        };
+        if (!result.text) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "out of memory building $add result");
+            return false;
+        }
+        memcpy(result.text, buffer, (size_t)written + 1);
+
+        bool ok = vm_stack_push(vm, &result);
+        vm_value_free(&result);
+        vm_value_free(&rhs);
+        vm_value_free(&lhs);
+        if (!ok) {
+            report_error(err_stream, "out of memory pushing $add result");
+        }
+        return ok;
+    }
+
+    if (strcmp(op_name, "$set") == 0) {
+        VmValue rhs = {0};
+        VmValue lhs = {0};
+        if (!vm_stack_pop(vm, &rhs) || !vm_stack_pop(vm, &lhs)) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "$set requires identifier and value operands");
+            return false;
+        }
+
+        if (lhs.kind != VM_VALUE_IDENT || !lhs.text) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "$set lhs must be an identifier");
+            return false;
+        }
+
+        if (!vm_set_slot(vm, lhs.text, &rhs)) {
+            vm_value_free(&rhs);
+            vm_value_free(&lhs);
+            report_error(err_stream, "failed to write slot during $set");
+            return false;
+        }
+
+        bool ok = vm_stack_push(vm, &rhs);
+        vm_value_free(&rhs);
+        vm_value_free(&lhs);
+        if (!ok) {
+            report_error(err_stream, "out of memory pushing $set result");
+        }
+        return ok;
+    }
+
+    {
+        FILE* out = err_stream ? err_stream : stderr;
+        fprintf(out,
+                "runtime error: unsupported operator '%s' (supported in V0.1: $add, $set)\n",
+                op_name);
+    }
+    return false;
+}
+
+bool morphl_vm_program_load(const char* path, MorphlVmProgram** out_program) {
+    if (!path || !out_program) {
+        return false;
+    }
+
+    *out_program = NULL;
+
+    FILE* file = fopen(path, "rb");
+    if (!file) {
+        return false;
+    }
+
+    if (fseek(file, 0, SEEK_END) != 0) {
+        fclose(file);
+        return false;
+    }
+
+    long file_size = ftell(file);
+    if (file_size < 0) {
+        fclose(file);
+        return false;
+    }
+
+    if (fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        return false;
+    }
+
+    uint8_t* bytes = malloc((size_t)file_size);
+    if (!bytes) {
+        fclose(file);
+        return false;
+    }
+
+    bool ok = (fread(bytes, 1, (size_t)file_size, file) == (size_t)file_size);
+    fclose(file);
+    if (!ok) {
+        free(bytes);
+        return false;
+    }
+
+    MorphlVmProgram* program = calloc(1, sizeof(MorphlVmProgram));
+    if (!program) {
+        free(bytes);
+        return false;
+    }
+
+    size_t off = 0;
+    if ((size_t)file_size < 4 || memcmp(bytes, MORPHL_VM_MAGIC, 4) != 0) {
+        free(bytes);
+        morphl_vm_program_free(program);
+        return false;
+    }
+    off += 4;
+
+    uint32_t reserved = 0;
+    uint32_t metadata_count = 0;
+    if (!read_u16(bytes, (size_t)file_size, &off, &program->version_major) ||
+        !read_u16(bytes, (size_t)file_size, &off, &program->version_minor) ||
+        !read_u32(bytes, (size_t)file_size, &off, &reserved) ||
+        !read_u32(bytes, (size_t)file_size, &off, &program->string_count)) {
+        free(bytes);
+        morphl_vm_program_free(program);
+        return false;
+    }
+
+    if (program->string_count > 0) {
+        program->strings = calloc(program->string_count, sizeof(char*));
+        if (!program->strings) {
+            free(bytes);
+            morphl_vm_program_free(program);
+            return false;
+        }
+    }
+
+    for (uint32_t i = 0; i < program->string_count; ++i) {
+        uint32_t len = 0;
+        if (!read_u32(bytes, (size_t)file_size, &off, &len) || (off + len) > (size_t)file_size) {
+            free(bytes);
+            morphl_vm_program_free(program);
+            return false;
+        }
+
+        char* text = malloc((size_t)len + 1);
+        if (!text) {
+            free(bytes);
+            morphl_vm_program_free(program);
+            return false;
+        }
+        memcpy(text, bytes + off, len);
+        text[len] = '\0';
+        off += len;
+        program->strings[i] = text;
+    }
+
+    if (!read_u32(bytes, (size_t)file_size, &off, &metadata_count)) {
+        free(bytes);
+        morphl_vm_program_free(program);
+        return false;
+    }
+
+    for (uint32_t i = 0; i < metadata_count; ++i) {
+        uint32_t key = 0;
+        uint32_t value = 0;
+        if (!read_u32(bytes, (size_t)file_size, &off, &key) ||
+            !read_u32(bytes, (size_t)file_size, &off, &value)) {
+            free(bytes);
+            morphl_vm_program_free(program);
+            return false;
+        }
+    }
+
+    if (!read_u32(bytes, (size_t)file_size, &off, &program->code_len) ||
+        (off + program->code_len) > (size_t)file_size) {
+        free(bytes);
+        morphl_vm_program_free(program);
+        return false;
+    }
+
+    if (program->code_len > 0) {
+        program->code = malloc(program->code_len);
+        if (!program->code) {
+            free(bytes);
+            morphl_vm_program_free(program);
+            return false;
+        }
+        memcpy(program->code, bytes + off, program->code_len);
+    }
+
+    free(bytes);
+    *out_program = program;
+    return true;
+}
+
+void morphl_vm_program_free(MorphlVmProgram* program) {
+    if (!program) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < program->string_count; ++i) {
+        free(program->strings[i]);
+    }
+    free(program->strings);
+    free(program->code);
+    free(program);
+}
+
+MorphlVm* morphl_vm_new(const MorphlVmProgram* program) {
+    if (!program) {
+        return NULL;
+    }
+
+    MorphlVm* vm = calloc(1, sizeof(MorphlVm));
+    if (!vm) {
+        return NULL;
+    }
+    vm->program = program;
+    return vm;
+}
+
+void morphl_vm_free(MorphlVm* vm) {
+    if (!vm) {
+        return;
+    }
+
+    for (size_t i = 0; i < vm->stack_count; ++i) {
+        vm_value_free(&vm->stack[i]);
+    }
+    free(vm->stack);
+
+    for (size_t i = 0; i < vm->slot_count; ++i) {
+        free(vm->slots[i].name);
+        vm_value_free(&vm->slots[i].value);
+    }
+    free(vm->slots);
+
+    free(vm);
+}
+
+bool morphl_vm_execute(MorphlVm* vm, FILE* err_stream) {
+    if (!vm || !vm->program || !vm->program->code) {
+        report_error(err_stream, "invalid VM state");
+        return false;
+    }
+
+    while (vm->ip < vm->program->code_len) {
+        uint8_t op = vm->program->code[vm->ip++];
+
+        if (op == VM_OP_HALT) {
+            return true;
+        }
+
+        if (op == VM_OP_PUSH_NULL) {
+            VmValue value = {.kind = VM_VALUE_NULL, .text = NULL, .items = NULL, .item_count = 0};
+            if (!vm_stack_push(vm, &value)) {
+                report_error(err_stream, "out of memory during PUSH_NULL");
+                return false;
+            }
+            continue;
+        }
+
+        if (op == VM_OP_PUSH_LITERAL || op == VM_OP_PUSH_IDENT) {
+            uint32_t idx = 0;
+            if ((vm->ip + 4) > vm->program->code_len) {
+                report_error(err_stream, "truncated PUSH payload");
+                return false;
+            }
+            idx = (uint32_t)vm->program->code[vm->ip] |
+                  ((uint32_t)vm->program->code[vm->ip + 1] << 8) |
+                  ((uint32_t)vm->program->code[vm->ip + 2] << 16) |
+                  ((uint32_t)vm->program->code[vm->ip + 3] << 24);
+            vm->ip += 4;
+
+            if (idx >= vm->program->string_count) {
+                report_error(err_stream, "string index out of bounds");
+                return false;
+            }
+
+            VmValue value = {
+                .kind = (op == VM_OP_PUSH_LITERAL) ? VM_VALUE_LITERAL : VM_VALUE_IDENT,
+                .text = vm->program->strings[idx],
+                .items = NULL,
+                .item_count = 0,
+            };
+            if (!vm_stack_push(vm, &value)) {
+                report_error(err_stream, "out of memory during PUSH");
+                return false;
+            }
+            continue;
+        }
+
+        if (op == VM_OP_MAKE_GROUP) {
+            uint32_t arity = 0;
+            if ((vm->ip + 4) > vm->program->code_len) {
+                report_error(err_stream, "truncated MAKE_GROUP payload");
+                return false;
+            }
+            arity = (uint32_t)vm->program->code[vm->ip] |
+                    ((uint32_t)vm->program->code[vm->ip + 1] << 8) |
+                    ((uint32_t)vm->program->code[vm->ip + 2] << 16) |
+                    ((uint32_t)vm->program->code[vm->ip + 3] << 24);
+            vm->ip += 4;
+
+            if ((size_t)arity > vm->stack_count) {
+                report_error(err_stream, "MAKE_GROUP arity exceeds stack depth");
+                return false;
+            }
+
+            VmValue group = {.kind = VM_VALUE_GROUP, .text = NULL, .items = NULL, .item_count = arity};
+            if (arity > 0) {
+                group.items = calloc(arity, sizeof(VmValue));
+                if (!group.items) {
+                    report_error(err_stream, "out of memory during MAKE_GROUP");
+                    return false;
+                }
+            }
+
+            for (size_t i = 0; i < arity; ++i) {
+                VmValue item = {0};
+                if (!vm_stack_pop(vm, &item)) {
+                    vm_value_free(&group);
+                    report_error(err_stream, "stack underflow during MAKE_GROUP");
+                    return false;
+                }
+                group.items[arity - i - 1] = item;
+            }
+
+            if (!vm_stack_push(vm, &group)) {
+                vm_value_free(&group);
+                report_error(err_stream, "out of memory pushing group");
+                return false;
+            }
+            vm_value_free(&group);
+            continue;
+        }
+
+        if (op == VM_OP_SET_SLOT) {
+            uint32_t idx = 0;
+            if ((vm->ip + 4) > vm->program->code_len) {
+                report_error(err_stream, "truncated SET_SLOT payload");
+                return false;
+            }
+            idx = (uint32_t)vm->program->code[vm->ip] |
+                  ((uint32_t)vm->program->code[vm->ip + 1] << 8) |
+                  ((uint32_t)vm->program->code[vm->ip + 2] << 16) |
+                  ((uint32_t)vm->program->code[vm->ip + 3] << 24);
+            vm->ip += 4;
+
+            if (idx >= vm->program->string_count) {
+                report_error(err_stream, "SET_SLOT index out of bounds");
+                return false;
+            }
+
+            VmValue value = {0};
+            if (!vm_stack_pop(vm, &value)) {
+                report_error(err_stream, "SET_SLOT requires a value on stack");
+                return false;
+            }
+
+            bool ok = vm_set_slot(vm, vm->program->strings[idx], &value);
+            if (ok) {
+                ok = vm_stack_push(vm, &value);
+            }
+            vm_value_free(&value);
+            if (!ok) {
+                report_error(err_stream, "failed to assign slot");
+                return false;
+            }
+            continue;
+        }
+
+        if (op == VM_OP_OPERATOR) {
+            uint32_t idx = 0;
+            if ((vm->ip + 4) > vm->program->code_len) {
+                report_error(err_stream, "truncated OPERATOR payload");
+                return false;
+            }
+            idx = (uint32_t)vm->program->code[vm->ip] |
+                  ((uint32_t)vm->program->code[vm->ip + 1] << 8) |
+                  ((uint32_t)vm->program->code[vm->ip + 2] << 16) |
+                  ((uint32_t)vm->program->code[vm->ip + 3] << 24);
+            vm->ip += 4;
+
+            if (idx >= vm->program->string_count) {
+                report_error(err_stream, "OPERATOR index out of bounds");
+                return false;
+            }
+
+            if (!vm_execute_operator(vm, vm->program->strings[idx], err_stream)) {
+                return false;
+            }
+            continue;
+        }
+
+        if (op == VM_OP_NODE_META) {
+            report_error(err_stream, "NODE_META execution is not supported in V0.1 runtime");
+            return false;
+        }
+
+        report_error(err_stream, "unknown opcode");
+        return false;
+    }
+
+    report_error(err_stream, "program terminated without HALT");
+    return false;
+}
+
+bool morphl_vm_run_file(const char* path, FILE* err_stream) {
+    MorphlVmProgram* program = NULL;
+    if (!morphl_vm_program_load(path, &program)) {
+        report_error(err_stream, "failed to load bytecode file");
+        return false;
+    }
+
+    MorphlVm* vm = morphl_vm_new(program);
+    if (!vm) {
+        report_error(err_stream, "failed to initialize VM");
+        morphl_vm_program_free(program);
+        return false;
+    }
+
+    bool ok = morphl_vm_execute(vm, err_stream);
+    morphl_vm_free(vm);
+    morphl_vm_program_free(program);
+    return ok;
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal end-to-end VM runtime so bytecode emitted by the VM backend can be executed immediately.
- Expose a small concrete runtime API for loading/executing MorphL VM bytecode files and integrate it into the existing CLI.

### Description

- Added a small runtime API header `include/runtime/runtime.h` with functions to load/free programs, create/destroy a VM, execute, and a convenience `morphl_vm_run_file` helper.
- Implemented a minimal bytecode interpreter in `src/runtime/vm_runtime.c` that parses `out.mbc` (magic/version/string table/metadata/code) and executes the V0.1 opcode subset: `PUSH_LITERAL`, `PUSH_IDENT`, `MAKE_GROUP`, `SET_SLOT`, `OPERATOR`, and `HALT`, with explicit rejection for `NODE_META`.
- Implemented V0.1 runtime operators `$add` and `$set` with clear failure messages for unsupported operators (`runtime error: unsupported operator '<name>' (supported in V0.1: $add, $set)`).
- Added a `morphl_runtime` library target and linked it into the `morphlc` executable, and extended `src/main.c` to support a `--run` flag that compiles with `--backend vm` and executes the produced `out.mbc`.
- Documented the supported V0.1 operators and failure semantics in `docs/backend/vm_bytecode.md`.

### Testing

- Built the project: `cmake -S . -B build && cmake --build build` (succeeded).
- Ran the test suite: `ctest --test-dir build --output-on-failure` (3 tests passed, 0 failed).
- Validated the runtime end-to-end: `./build/src/morphlc --backend vm --run /tmp/vm_v01.src` (compiled `out.mbc` and VM execution succeeded).
- Verified unsupported-operator behavior: `./build/src/morphlc --backend vm --run /tmp/vm_fail.src` returned non-zero and printed the expected unsupported operator runtime error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad83a7c8f0832fa34800140207ce6e)